### PR TITLE
Fix for the invalid text length limit

### DIFF
--- a/http/messageadd.go
+++ b/http/messageadd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"unicode/utf8"
 
 	"technochat/db"
 )
@@ -55,8 +56,10 @@ func (req *MessageAddRequest) Validate() error {
 	if len(req.text) == 0 {
 		return fmt.Errorf("empty text")
 	}
-
-	if len(req.text) > maxTextLength {
+	if !utf8.ValidString(req.text) {
+		return fmt.Errorf("text must be a valid UTF8 string")
+	}
+	if utf8.RuneCountInString(req.text) > maxTextLength {
 		return fmt.Errorf("maximum text length of %d is allowed", maxTextLength)
 	}
 

--- a/static/html/messageadd.html
+++ b/static/html/messageadd.html
@@ -15,7 +15,7 @@
             $('#result_text').html('');
             $('#result_link').html('');
 
-            $('form').submit(onMessageSubmit);
+            $('#text_form').submit(onMessageSubmit);
 
             $('.button__generate').on('click', function () {
                 $('.message__box').css('display', 'block');
@@ -31,7 +31,9 @@
         </h1>
     </div>
 
-    <form class="form" id="text_form" action="/api/v1/message/add" method="post" enctype="multipart/form-data">
+    <form class="form" id="text_form" action="/api/v1/message/add"
+          method="post" enctype="multipart/form-data" accept-charset="utf-8">
+
         <p>Leave a self-destructive message:</p>
 
         <textarea id="text" class="area__message" name="text" maxlength="1024" autofocus="true"

--- a/static/html/messageview.html
+++ b/static/html/messageview.html
@@ -16,7 +16,7 @@
             $('#result_text').html('');
             $('#result_link').html('');
 
-            $('form').submit(onMessageSubmit);
+            $('#text_form').submit(onMessageSubmit);
 
             $('.button__generate').on('click', function () {
                 $('.message__box').css('display', 'block');
@@ -35,8 +35,10 @@
     <p>Message: </p>
     <p id=message class="result__message"></p>
 
-    <form class="form" id="text_form" action="/api/v1/message/add" method="post" enctype="multipart/form-data">
-        <p>Your answer: </p>
+    <form class="form" id="text_form" action="/api/v1/message/add"
+          method="post" enctype="multipart/form-data" accept-charset="utf-8">
+
+        <p>Your reply: </p>
 
         <textarea id="text" class="area__message" name="text" maxlength="1024" placeholder="Right here"></textarea>
 

--- a/static/js/message/add.js
+++ b/static/js/message/add.js
@@ -6,7 +6,7 @@ function onMessageSubmit(e) {
     $.ajax({
         type: 'POST',
         url: $(this).attr('action'),
-        data: new FormData($('form')[0]),
+        data: new FormData($('#text_form')[0]),
         contentType: false,
         processData: false,
         success: onMessageSubmitSuccess,
@@ -33,7 +33,7 @@ function onMessageSubmitSuccess(addResponse) {
         var link = addResponse.body.link;
         $('#result_link').html('<input id="to_copy" value="' + link + '">' + link + '</input>');
     } else {
-        $('#result_link').html(addResponse.body);
+        $('#result_link').html("error: " + addResponse.body);
     }
 
     scrollToCopyButton();


### PR DESCRIPTION
Currently when validating the given text length we count the number of bytes which is wrong since a utf8 rune can consist of more than one byte. Fixed

Also added a check if the given text is valid utf8 string

Resolves #60