### PR TITLE
Fix message rendering XSS and Redis expiry handling

### DIFF
--- a/db/redis/image.go
+++ b/db/redis/image.go
@@ -18,9 +18,16 @@ func (r *Redis) AddImage(img entity.Image) error {
 	if err := r.pool.Cmd(
 		"HMSET", key,
 		imgBodyKey, img.Body,
-		"EX", img.TTL,
 	).Err; err != nil {
 		return fmt.Errorf("could not add image: %w", err)
+	}
+
+	if err := r.pool.Cmd("EXPIRE", key, img.TTL).Err; err != nil {
+		if delErr := r.pool.Cmd("DEL", key).Err; delErr != nil {
+			return fmt.Errorf("could not set TTL for image and cleanup failed: %w", delErr)
+		}
+
+		return fmt.Errorf("could not set TTL for image: %w", err)
 	}
 
 	return nil

--- a/db/redis/message.go
+++ b/db/redis/message.go
@@ -19,9 +19,16 @@ func (r *Redis) AddMessage(message entity.Message) error {
 		"HMSET", key,
 		msgTextKey, message.Text,
 		msgImagesKey, message.Images.Encode(),
-		"EX", message.TTL,
 	).Err; err != nil {
 		return fmt.Errorf("could not add message: %w", err)
+	}
+
+	if err := r.pool.Cmd("EXPIRE", key, message.TTL).Err; err != nil {
+		if delErr := r.pool.Cmd("DEL", key).Err; delErr != nil {
+			return fmt.Errorf("could not set TTL for message and cleanup failed: %w", delErr)
+		}
+
+		return fmt.Errorf("could not set TTL for message: %w", err)
 	}
 
 	return nil

--- a/static/js/message/view.js
+++ b/static/js/message/view.js
@@ -15,7 +15,8 @@ async function loadMessage(msgId, key, iv, msgDiv) {
                 await decrypter.setup(Base64ToArrayBuffer(key), Base64ToArrayBuffer(iv));
 
                 let decryptedMsg = await decrypter.decryptToString(encryptedMsg);
-                msgDiv.html(decryptedMsg.replace(/(?:\r\n|\r|\n)/g, '<br>'))
+                msgDiv.text(decryptedMsg)
+                msgDiv.css('white-space', 'pre-wrap')
             } catch (error) {
                 console.error(error);
                 msgDiv.html('Could not decrypt message, the link was possibly corrupted');


### PR DESCRIPTION
## Summary
- render decrypted messages as plain text instead of HTML to prevent script execution
- preserve message formatting with white-space: pre-wrap
- apply real Redis expiry to stored messages and images using EXPIRE
- delete keys if TTL setup fails so data is not left behind indefinitely

## Testing
- make test
- make lint was attempted earlier in this workflow but hung without producing output in the local environment