### PR TITLE
[codex] Reset copy button on new link generation

### DIFF
--- a/static/js/chat/init.js
+++ b/static/js/chat/init.js
@@ -5,6 +5,7 @@ let joinButtonView;
 
 function onSubmit(e) {
     $("#loading").show();
+    util.resetCopyButton('copy_button');
     e.preventDefault();
 
     var fd = new FormData($("form")[0]);

--- a/static/js/message/add.js
+++ b/static/js/message/add.js
@@ -328,7 +328,7 @@ function getCurrentTTL() {
 
 async function onMessageSubmit(e) {
     $('#loading').show();
-    $('#copy_button').html('Copy link');
+    util.resetCopyButton('copy_button');
     e.preventDefault();
 
     if (isPreparingImages) {

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -30,6 +30,16 @@ export function copyButton(button, input) {
     });
 }
 
+export function resetCopyButton(button, text = 'Copy link') {
+    const copyButton = document.getElementById(button);
+
+    if (!copyButton) {
+        return;
+    }
+
+    copyButton.textContent = text;
+}
+
 export function scrollToCopyButton() {
     $('html, body').animate({
         scrollTop: $('#copy_button').offset().top

--- a/ui-tests/tests/chat-init.unit.spec.js
+++ b/ui-tests/tests/chat-init.unit.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require("@playwright/test");
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        async writeText(value) {
+          window.__copiedText = value;
+        },
+      },
+    });
+  });
+});
+
+test("@unit resets the copy button when a new chat link is generated", async ({
+  page,
+}) => {
+  let responseIndex = 0;
+  const chatIDs = ["first-chat", "second-chat"];
+
+  await page.route("**/api/v1/chat/init", async (route) => {
+    const chatID = chatIDs[responseIndex];
+    responseIndex += 1;
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          id: chatID,
+        },
+      }),
+    });
+  });
+
+  await page.goto("/html/initchat.html");
+  await page.locator("button", { hasText: "Create chat" }).click();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/first-chat/);
+  await page.locator("#copy_button").click();
+  await expect(page.locator("#copy_button")).toHaveText("Copied!");
+
+  await page.locator("button", { hasText: "Create chat" }).click();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/second-chat/);
+  await expect(page.locator("#copy_button")).toHaveText("Copy link");
+});

--- a/ui-tests/tests/message-add.unit.spec.js
+++ b/ui-tests/tests/message-add.unit.spec.js
@@ -78,6 +78,42 @@ test("@unit renders the generated link and copies it from a mocked API response"
   await expect(page.locator("#copy_button")).toHaveText("Copied!");
 });
 
+test("@unit resets the copy button when a new message link is generated", async ({
+  page,
+}) => {
+  let responseIndex = 0;
+  const messageIDs = ["first-message", "second-message"];
+
+  await page.route("**/api/v1/message/add", async (route) => {
+    const messageID = messageIDs[responseIndex];
+    responseIndex += 1;
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          link: `https://127.0.0.1/html/messageview.html?id=${messageID}`,
+        },
+      }),
+    });
+  });
+
+  await page.goto("/html/messageadd.html");
+  await page.locator("#text").fill("first message");
+  await page.locator("#generate_button").click();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/first-message#key=/);
+  await page.locator("#copy_button").click();
+  await expect(page.locator("#copy_button")).toHaveText("Copied!");
+
+  await page.locator("#text").fill("second message");
+  await page.locator("#generate_button").click();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/second-message#key=/);
+  await expect(page.locator("#copy_button")).toHaveText("Copy link");
+});
+
 test("@unit renders API validation errors without clearing the original text", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Reset the copy button label before generating a new message or chat link.
- Add regression unit coverage for message link and chat link regeneration.

## Root cause
After a successful copy, the shared copy handler changed the button text to `Copied!`, but chat link generation did not reset that state. Message generation had an inline reset, so this change moves the behavior into a shared helper and uses it consistently.

Closes #92.
