### PR TITLE
[codex] Add image upload UI tests

### DIFF
--- a/static/js/message/add.js
+++ b/static/js/message/add.js
@@ -193,6 +193,11 @@ function createDeleteButton(imgIndex) {
             URL.revokeObjectURL(removedImages[0].previewUrl);
         }
 
+        const fileInput = document.getElementById(fileInputId);
+        if (fileInput) {
+            fileInput.value = '';
+        }
+
         renderImagesPreview();
     });
 

--- a/ui-tests/tests/message-add.unit.spec.js
+++ b/ui-tests/tests/message-add.unit.spec.js
@@ -1,5 +1,10 @@
 const { test, expect } = require("@playwright/test");
 
+const tinyPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "clipboard", {
@@ -100,4 +105,142 @@ test("@unit renders API validation errors without clearing the original text", a
     "error: maximum text length of 2048 is allowed"
   );
   await expect(page.locator("#text")).toHaveValue("please keep this draft");
+});
+
+test("@unit uploads multiple queued images and attaches all returned ids to the message", async ({
+  page,
+}) => {
+  const imageIds = [
+    "6a938b32-e701-4807-b099-ddfbd19ecd22",
+    "46f46909-4871-4a98-b3a7-be605032efe5",
+  ];
+  let imageUploadCount = 0;
+
+  await page.route("**/api/v1/image/add", async (route) => {
+    const id = imageIds[imageUploadCount];
+    imageUploadCount++;
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: { id },
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/message/add", async (route) => {
+    const body = route.request().postData();
+    expect(body).toContain(imageIds.join(","));
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          link: "https://127.0.0.1/html/messageview.html?id=unit-message",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/html/messageadd.html");
+  await page.setInputFiles("#file-input", [
+    {
+      name: "first.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+    {
+      name: "second.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+  ]);
+
+  await expect(page.locator("#preview .upload__img")).toHaveCount(2);
+
+  await page.locator("#text").fill("secret with images");
+  await page.locator("#generate_button").click();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/unit-message#key=/);
+  expect(imageUploadCount).toBe(2);
+});
+
+test("@unit removes an image from the upload queue before submit", async ({
+  page,
+}) => {
+  let imageUploadCount = 0;
+
+  await page.route("**/api/v1/image/add", async (route) => {
+    imageUploadCount++;
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: { id: "6a938b32-e701-4807-b099-ddfbd19ecd22" },
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/message/add", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          link: "https://127.0.0.1/html/messageview.html?id=unit-message",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/html/messageadd.html");
+  await page.setInputFiles("#file-input", [
+    {
+      name: "keep.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+    {
+      name: "remove.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+  ]);
+
+  await expect(page.locator("#preview .upload__img")).toHaveCount(2);
+
+  await page.locator("#preview .upload__delete").nth(1).click();
+  await expect(page.locator("#preview .upload__img")).toHaveCount(1);
+
+  await page.locator("#text").fill("secret with one image");
+  await page.locator("#generate_button").click();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/unit-message#key=/);
+  expect(imageUploadCount).toBe(1);
+});
+
+test("@unit allows selecting the same image again after removing it from the queue", async ({
+  page,
+}) => {
+  await page.goto("/html/messageadd.html");
+
+  await page.setInputFiles("#file-input", {
+    name: "same-image.png",
+    mimeType: "image/png",
+    buffer: tinyPng,
+  });
+  await expect(page.locator("#preview .upload__img")).toHaveCount(1);
+
+  await page.locator("#preview .upload__delete").click();
+  await expect(page.locator("#preview .upload__img")).toHaveCount(0);
+
+  await page.setInputFiles("#file-input", {
+    name: "same-image.png",
+    mimeType: "image/png",
+    buffer: tinyPng,
+  });
+  await expect(page.locator("#preview .upload__img")).toHaveCount(1);
 });

--- a/ui-tests/tests/message-flow.e2e.spec.js
+++ b/ui-tests/tests/message-flow.e2e.spec.js
@@ -1,5 +1,10 @@
 const { test, expect } = require("@playwright/test");
 
+const tinyPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
 test("@e2e creates, opens, decrypts, and consumes a one-time message", async ({
   page,
   browser,
@@ -38,6 +43,61 @@ test("@e2e creates, opens, decrypts, and consumes a one-time message", async ({
     );
   } finally {
     await replyViewPage.close();
+  }
+
+  const secondViewPage = await browser.newPage();
+  try {
+    await secondViewPage.goto(messageLink);
+    await expect(secondViewPage.locator("#message")).toHaveText(/not found/i);
+  } finally {
+    await secondViewPage.close();
+  }
+});
+
+test("@e2e creates, opens, decrypts, and renders message images", async ({
+  page,
+  browser,
+}) => {
+  const messageText = "secret images from playwright";
+
+  await page.goto("/html/messageadd.html");
+  await page.locator("#text").fill(messageText);
+  await page.setInputFiles("#file-input", [
+    {
+      name: "secret-one.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+    {
+      name: "secret-two.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+    {
+      name: "secret-three.png",
+      mimeType: "image/png",
+      buffer: tinyPng,
+    },
+  ]);
+
+  await expect(page.locator("#preview .upload__img")).toHaveCount(3);
+
+  await page.locator("#generate_button").click();
+
+  const linkInput = page.locator("#to_copy");
+  await expect(linkInput).toHaveValue(
+    /\/html\/messageview\.html\?id=.*#key=.*&iv=.*/
+  );
+
+  const messageLink = await linkInput.inputValue();
+  await page.goto(messageLink);
+
+  await expect(page.locator("#message")).toHaveText(messageText);
+  await expect(page.locator("#images img")).toHaveCount(3);
+
+  for (const image of await page.locator("#images img").all()) {
+    await expect(image).toHaveJSProperty("naturalWidth", 1);
+    await expect(image).toHaveJSProperty("naturalHeight", 1);
   }
 
   const secondViewPage = await browser.newPage();

--- a/ui-tests/tests/message-view.unit.spec.js
+++ b/ui-tests/tests/message-view.unit.spec.js
@@ -1,0 +1,104 @@
+const { test, expect } = require("@playwright/test");
+
+function arrayBufferToBase64(buf) {
+  return Buffer.from(new Uint8Array(buf)).toString("base64");
+}
+
+const tinyPng = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
+async function encryptFixture(text, imageBytes) {
+  const key = await crypto.subtle.generateKey(
+    { name: "AES-GCM", length: 128 },
+    true,
+    ["encrypt", "decrypt"]
+  );
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const exportKey = await crypto.subtle.exportKey("raw", key);
+
+  const textCipher = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(text)
+  );
+  const imageCipher = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    imageBytes
+  );
+
+  return {
+    key: arrayBufferToBase64(exportKey),
+    iv: arrayBufferToBase64(iv),
+    textCipherBase64: arrayBufferToBase64(textCipher),
+    imageCipherBytes: Buffer.from(new Uint8Array(imageCipher)),
+  };
+}
+
+test("@unit decrypts encrypted message and image from the view API while showing the image loader", async ({
+  page,
+}) => {
+  const plainText = "plain text that must not arrive from the API";
+  const plainImage = tinyPng;
+  const imageID = "6a938b32-e701-4807-b099-ddfbd19ecd22";
+  const encrypted = await encryptFixture(plainText, plainImage);
+
+  expect(encrypted.textCipherBase64).not.toContain(plainText);
+  expect(encrypted.imageCipherBytes.equals(plainImage)).toBeFalsy();
+  expect(encrypted.imageCipherBytes.includes(Buffer.from("PNG"))).toBeFalsy();
+
+  let fulfillImage;
+  const imageResponseReady = new Promise((resolve) => {
+    fulfillImage = resolve;
+  });
+
+  await page.route("**/api/v1/message/view?id=unit-message", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          text: encrypted.textCipherBase64,
+          imgs: [imageID],
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/image/view", async (route) => {
+    await imageResponseReady;
+
+    await route.fulfill({
+      contentType: "application/octet-stream",
+      body: encrypted.imageCipherBytes,
+    });
+  });
+
+  const viewURL =
+    "/html/messageview.html?id=unit-message#key=" +
+    encodeURIComponent(encrypted.key) +
+    "&iv=" +
+    encodeURIComponent(encrypted.iv);
+
+  await page.goto(viewURL);
+
+  await expect(page.locator("#message")).toHaveText(plainText);
+  await expect(page.locator("#images .result__image-loader")).toHaveCount(1);
+
+  fulfillImage();
+
+  await expect(page.locator("#images img")).toHaveCount(1);
+  const loadedImageURL = await page.locator("#images img").getAttribute("src");
+  expect(loadedImageURL).toMatch(/^blob:/);
+
+  const loadedImageBytes = await page.evaluate(async (url) => {
+    const resp = await fetch(url);
+    const buf = await resp.arrayBuffer();
+    return Array.from(new Uint8Array(buf));
+  }, loadedImageURL);
+
+  expect(Buffer.from(loadedImageBytes).equals(plainImage)).toBeTruthy();
+  await expect(page.locator("#images .result__image-loader")).toHaveCount(0);
+});


### PR DESCRIPTION
## What changed

- Added UI unit coverage for multi-image upload queues, removing queued images, and re-selecting the same image after removal.
- Added a message view unit test that serves encrypted text and encrypted image bytes, waits on the image loader, and verifies the decrypted blob matches the original PNG bytes.
- Added an e2e flow that uploads multiple images, opens the generated message link, decrypts the message, and verifies all images render.
- Clears the file input after removing an image from the queue so selecting the same file again triggers the browser change flow.

## Why

Image upload behavior now depends on client-side queue handling and client-side AES-GCM encryption/decryption. These tests cover the user-facing paths most likely to regress without duplicating backend coverage that already exists.

## Validation

- make lint
- make test
