### PR TITLE
Added encrypted temporary chat messages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.64.5
+        version: v2.11.4
         only-new-issues: true
         skip-go-installation: true
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,16 +13,15 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: 1.18
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v8
       with:
         version: v2.11.4
         only-new-issues: true
-        skip-go-installation: true
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 .DS_store
 .idea
+.cache/
 
 /bin
 /vendor/pkg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 MODULE_NAME=technochat
+GOLANGCI_LINT_VERSION = v2.11.4
+GO_BUILD_CACHE ?= $(CURDIR)/.cache/go-build
+GOLANGCI_LINT_CACHE ?= $(CURDIR)/.cache/golangci-lint
 
 TEST_FILES = $(shell find -L * -name '*_test.go' -not -path "vendor/*")
 TEST_PACKAGES = $(dir $(addprefix $(MODULE_NAME)/,$(TEST_FILES)))
@@ -18,12 +21,12 @@ install: lint go-tests ui-tests technochat
 technochat:
 	go build $(GO_BUILD_FLAGS) -mod vendor -o bin/technochat ./cmd/technochat
 
-bin/golangci-lint:
-	@echo "building golangci-lint v1.64.5 with $$(go env GOVERSION)"
-	GOBIN=$(CURDIR)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
+bin/golangci-lint: Makefile
+	@echo "building golangci-lint $(GOLANGCI_LINT_VERSION) with $$(go env GOVERSION)"
+	GOCACHE=$(GO_BUILD_CACHE) GOBIN=$(CURDIR)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 lint: bin/golangci-lint
-	bin/golangci-lint run -v -c golangci.yml --new-from-rev=$(TARGET_BRANCH)
+	GOLANGCI_LINT_CACHE=$(GOLANGCI_LINT_CACHE) bin/golangci-lint run -v -c golangci.yml --new-from-rev=$(TARGET_BRANCH)
 
 go-tests:
 	go test -v $(TEST_PACKAGES)

--- a/README.md
+++ b/README.md
@@ -25,19 +25,6 @@ that room key and a fresh random IV before `WebSocket.send`. The server assigns
 participant names, enforces the join limit, and relays WebSocket JSON, but it
 only sees ciphertext for user message bodies.
 
-This protects past chat contents from later server-side storage access and keeps
-message text out of normal server request handling, logs, and relay logic. It
-does not protect against a compromised server changing the JavaScript delivered
-to browsers, malicious invitation-link recipients, browser/device compromise, or
-the server replacing client code during a live session. Temporary chat service
-events such as join/leave notifications and generated participant names are
-metadata and are not encrypted.
-
-The current chat bootstrap uses a shared symmetric room key carried in the
-invitation link. It does not provide participant key authentication or forward
-secrecy; adding authenticated participant keys is the next step if the server
-itself must be unable to perform key-substitution attacks.
-
 Default local service ports in the dev stack:
 - `80` and `443` for Nginx;
 - internal `8080` for the Go application;

--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ The project exposes HTTP API endpoints and static pages for three main scenarios
 - open a message by link and delete it after reading;
 - create a temporary chat room with a limited number of participants.
 
+## Security model
+
+One-time messages and temporary chat message bodies are encrypted in the browser
+before they are sent to the Go backend.
+
+For temporary chats, the room creator generates an AES-GCM-128 room key in the
+browser. The key is added to the invitation URL fragment as `#key=...`, so it is
+not sent in HTTP requests or WebSocket URLs. Every chat message is encrypted with
+that room key and a fresh random IV before `WebSocket.send`. The server assigns
+participant names, enforces the join limit, and relays WebSocket JSON, but it
+only sees ciphertext for user message bodies.
+
+This protects past chat contents from later server-side storage access and keeps
+message text out of normal server request handling, logs, and relay logic. It
+does not protect against a compromised server changing the JavaScript delivered
+to browsers, malicious invitation-link recipients, browser/device compromise, or
+the server replacing client code during a live session. Temporary chat service
+events such as join/leave notifications and generated participant names are
+metadata and are not encrypted.
+
+The current chat bootstrap uses a shared symmetric room key carried in the
+invitation link. It does not provide participant key authentication or forward
+secrecy; adding authenticated participant keys is the next step if the server
+itself must be unable to perform key-substitution attacks.
+
 Default local service ports in the dev stack:
 - `80` and `443` for Nginx;
 - internal `8080` for the Go application;

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,73 +1,15 @@
-# This file contains all available configuration options
-# with their default values.
-
-# options for analysis running
+version: "2"
 run:
-  # default concurrency is a available CPU number
-  #concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 60m
-
-  # include test files or not, default is true
-  tests: false
-
-  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
-  # If invoked with -mod=readonly, the go command is disallowed from the implicit
-  # automatic updating of go.mod described above. Instead, it fails when any changes
-  # to go.mod are needed. This setting is most useful to check that go.mod does
-  # not need updates, such as in a continuous integration and testing system.
-  # If invoked with -mod=vendor, the go command assumes that the vendor
-  # directory holds the correct copies of dependencies and ignores
-  # the dependency descriptions in go.mod.
   modules-download-mode: vendor
-
-# all available settings of specific linters
-linters-settings:
-  errcheck:
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: true
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 15
-  gocognit:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 20
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 200
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 100
-  funlen:
-    lines: 100
-    statements: 50
-  dogsled:
-    # checks assignments with too many blank identifiers; default is 2
-    max-blank-identifiers: 2
-  whitespace:
-    multi-if: false # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
-  wsl:
-    # If true append is only allowed to be cuddled if appending value is
-    # matching variables, fields or types on line above. Default is true.
-    strict-append: true
-    # Allow declarations (var) to be cuddled.
-    allow-cuddle-declarations: false
-    # Allow trailing comments in ending of blocks
-    allow-trailing-comment: false
-    # Force newlines in end of case at this limit (0 = never).
-    force-case-trailing-whitespace: 0
-  gomnd:
-    settings:
-      mnd:
-        # the list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
-        checks: argument,case,condition,operation,return,assign
-
+  tests: false
+  timeout: 60m
+output:
+  formats:
+    tab:
+      path: stdout
+      colors: false
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dupl
@@ -75,61 +17,91 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    # - gomnd
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - prealloc
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-    # - wsl
-  fast: false
-
+  settings:
+    dogsled:
+      max-blank-identifiers: 2
+    dupl:
+      threshold: 200
+    errcheck:
+      check-blank: true
+    funlen:
+      lines: 100
+      statements: 50
+    gocognit:
+      min-complexity: 20
+    gocyclo:
+      min-complexity: 15
+    lll:
+      line-length: 100
+    whitespace:
+      multi-if: false
+      multi-func: false
+    wsl:
+      strict-append: true
+      force-case-trailing-whitespace: 0
+      allow-trailing-comment: false
+      allow-cuddle-declarations: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: '^//go:generate '
+      - linters:
+          - lll
+          - mnd
+        path: cfg\.go
+      - linters:
+          - lll
+          - mnd
+        path: metrics\.go
+      - linters:
+          - gosec
+        text: 'G108:'
+    paths:
+      - .pb.go
+      - .svc.go
+      - bin$
+      - \.git$
+      - static
+      - dist
+      - vendor$
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-dirs:
-    - bin$
-    - \.git$
-    - static
-    - dist
-    - vendor$
-  exclude-files:
-    - ".pb.go"
-    - ".svc.go"
   max-issues-per-linter: 0
   max-same-issues: 0
-
-  exclude-use-default: true
-  exclude-rules:
-    # Exclude lll issues for long lines with go:generate
-    - linters:
-        - lll
-      source: "^//go:generate "
-
-    # Exclude lll issues in files which do not actually suffer from long lines and magic numbers
-    - path: cfg\.go
-      linters:
-        - lll
-        - gomnd
-    - path: metrics\.go
-      linters:
-        - lll
-        - gomnd
-
-    - linters:
-        - gosec
-      text: "G108:"
-
-output:
-  formats:
-    - format: tab
-      path: stdout
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - .pb.go
+      - .svc.go
+      - bin$
+      - \.git$
+      - static
+      - dist
+      - vendor$
+      - third_party$
+      - builtin$
+      - examples$

--- a/static/html/joinchat.html
+++ b/static/html/joinchat.html
@@ -57,6 +57,6 @@
     <script src="/js/lib/materialize.min.js"></script>
     <script src="/js/lib/PageTitleNotification.js"></script>
     <script src="/js/pwa.js"></script>
-    <script src="/js/chat/chat.js"></script>
+    <script type="module" src="/js/chat/chat.js"></script>
 </body>
 </html>

--- a/static/js/chat/chat.js
+++ b/static/js/chat/chat.js
@@ -1,3 +1,9 @@
+import {
+    DecryptStringWithAESGCM128Key,
+    EncryptStringWithAESGCM128Key,
+    ImportAESGCM128Key
+} from "/js/message/crypto.js";
+
 const WSMsgTypeService  = 0;
 const WSMsgTypeMessage = 1;
 
@@ -24,53 +30,90 @@ new Vue({
         name: '',
         onPage: false,
         newMessagesNum: 0,
+        roomKey: null,
     },
     created: function() {
-        var self = this;
         var id = getParameterByName('id', window.location);
-        var wsProtocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-        this.ws = new WebSocket(wsProtocol + window.location.host + '/api/v1/chat/connect?id=' + id);
-        this.ws.addEventListener('open', function() {
-            console.log('chat websocket opened for chat', id);
-        });
-        this.ws.addEventListener('message', function(e) {
-            var msg = JSON.parse(e.data);
-            console.log(msg);
-            switch (msg.type){
-                case WSMsgTypeService:
-                    if (msg.data.event_id == EventConnInitOk ){
-                        self.name = msg.data.event_data;
-                        self.username = msg.data.event_data;
-                    }
-                    if (msg.data.event_id == EventConnInitNoSuchChat || msg.data.event_id == EventConnInitMaxUsrsReached ){
-                        self.okconnected = false;
-                    }
-                    break;
-                case WSMsgTypeMessage:
-                    self.addmsg(msg);
-                    break;
-                default:
-                    alert("unknown response type:"+msg.type);
-            }
-        });
-        this.ws.addEventListener('error', function(e) {
-            console.log('chat websocket error', e);
-        });
-        this.ws.addEventListener('close', function(e) {
-            console.log('chat websocket closed', {
-                code: e.code,
-                reason: e.reason,
-                wasClean: e.wasClean,
-            });
-            self.okconnected = false;
-        });
+        var anchorParams = new URLSearchParams(window.location.hash.slice(1));
+        var key = anchorParams.get('key');
+
+        if (!id || !key) {
+            this.okconnected = false;
+            return;
+        }
+
+        this.setupEncryptedChat(id, key);
     },
     methods: {
-        addmsg: function(msg){
+        setupEncryptedChat: async function(id, key) {
+            var self = this;
+
+            try {
+                this.roomKey = await ImportAESGCM128Key(key);
+            } catch (e) {
+                console.error('could not import chat key', e);
+                this.okconnected = false;
+                return;
+            }
+
+            var wsProtocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+            this.ws = new WebSocket(wsProtocol + window.location.host + '/api/v1/chat/connect?id=' + id);
+            this.ws.addEventListener('open', function() {
+                console.log('chat websocket opened for chat', id);
+            });
+            this.ws.addEventListener('message', function(e) {
+                var msg = JSON.parse(e.data);
+                console.log(msg);
+                switch (msg.type){
+                    case WSMsgTypeService:
+                        if (msg.data.event_id == EventConnInitOk ){
+                            self.name = msg.data.event_data;
+                            self.username = msg.data.event_data;
+                        }
+                        if (msg.data.event_id == EventConnInitNoSuchChat || msg.data.event_id == EventConnInitMaxUsrsReached ){
+                            self.okconnected = false;
+                        }
+                        break;
+                    case WSMsgTypeMessage:
+                        self.addmsg(msg);
+                        break;
+                    default:
+                        alert("unknown response type:"+msg.type);
+                }
+            });
+            this.ws.addEventListener('error', function(e) {
+                console.log('chat websocket error', e);
+            });
+            this.ws.addEventListener('close', function(e) {
+                console.log('chat websocket closed', {
+                    code: e.code,
+                    reason: e.reason,
+                    wasClean: e.wasClean,
+                });
+                self.okconnected = false;
+            });
+        },
+        decryptMessageData: async function(msg) {
+            if (msg.username === 'server') {
+                return String(msg.data || '');
+            }
+
+            return await DecryptStringWithAESGCM128Key(this.roomKey, msg.data);
+        },
+        addmsg: async function(msg){
             if (document.hidden) {
                 pageTitleNotification.on(NewMsgTitle);
             }
             var username = msg.username || '';
+            var body = '';
+
+            try {
+                body = await this.decryptMessageData(msg);
+            } catch (e) {
+                console.error('could not decrypt chat message', e);
+                body = 'Could not decrypt chat message';
+            }
+
             var ownMessageClass = this.isOwnMessage(username) ? ' chat-message--own' : '';
             this.chatContent += '<div class="chat-message' + ownMessageClass + '">'
                 + '<div class="chip" >'
@@ -78,18 +121,28 @@ new Vue({
                 + this.escapeHtml(username)
                 + '</div>'
                 + '<div class="chat-message_body">'
-                + emojione.toImage(msg.data)
+                + emojione.toImage(this.escapeHtml(body))
                 + '</div>'
                 + '</div>';
             this.scrollToBottom();
         },
-        send: function () {
+        send: async function () {
             if (this.newMsg != '') {
+                var plaintext = $('<p>').html(this.newMsg).text();
+                var encryptedData;
+
+                try {
+                    encryptedData = await EncryptStringWithAESGCM128Key(this.roomKey, plaintext);
+                } catch (e) {
+                    console.error('could not encrypt chat message', e);
+                    return;
+                }
+
                 this.ws.send(
                     JSON.stringify({
                         type:1,
                         username: this.username,
-                        data: $('<p>').html(this.newMsg).text()
+                        data: encryptedData
                     })
                 );
                 this.newMsg = '';

--- a/static/js/chat/chat.js
+++ b/static/js/chat/chat.js
@@ -1,7 +1,8 @@
 import {
-    DecryptStringWithAESGCM128Key,
-    EncryptStringWithAESGCM128Key,
-    ImportAESGCM128Key
+    AESGCM128,
+    Base64ToArrayBuffer,
+    Decrypter,
+    Encrypter
 } from "/js/message/crypto.js";
 
 const WSMsgTypeService  = 0;
@@ -30,7 +31,8 @@ new Vue({
         name: '',
         onPage: false,
         newMessagesNum: 0,
-        roomKey: null,
+        roomKey: '',
+        encrypter: null,
     },
     created: function() {
         var id = getParameterByName('id', window.location);
@@ -49,7 +51,9 @@ new Vue({
             var self = this;
 
             try {
-                this.roomKey = await ImportAESGCM128Key(key);
+                this.roomKey = key;
+                this.encrypter = new Encrypter(new AESGCM128());
+                await this.encrypter.setupWithKey(Base64ToArrayBuffer(key));
             } catch (e) {
                 console.error('could not import chat key', e);
                 this.okconnected = false;
@@ -98,7 +102,17 @@ new Vue({
                 return String(msg.data || '');
             }
 
-            return await DecryptStringWithAESGCM128Key(this.roomKey, msg.data);
+            if (!msg.data || msg.data.alg !== 'AES-GCM-128' || !msg.data.iv || !msg.data.ciphertext) {
+                throw new Error('invalid encrypted payload');
+            }
+
+            var decrypter = new Decrypter(new AESGCM128());
+            await decrypter.setup(
+                Base64ToArrayBuffer(this.roomKey),
+                Base64ToArrayBuffer(msg.data.iv)
+            );
+
+            return await decrypter.decryptToString(Base64ToArrayBuffer(msg.data.ciphertext));
         },
         addmsg: async function(msg){
             if (document.hidden) {
@@ -132,7 +146,7 @@ new Vue({
                 var encryptedData;
 
                 try {
-                    encryptedData = await EncryptStringWithAESGCM128Key(this.roomKey, plaintext);
+                    encryptedData = await this.encrypter.encryptStringWithNewIV(plaintext);
                 } catch (e) {
                     console.error('could not encrypt chat message', e);
                     return;

--- a/static/js/chat/init.js
+++ b/static/js/chat/init.js
@@ -1,5 +1,5 @@
 import * as util from "/js/util.js";
-import {GenerateAESGCM128KeyBase64} from "/js/message/crypto.js";
+import {AESGCM128, ArrayBufferToBase64, Encrypter} from "/js/message/crypto.js";
 
 let copyButtonView;
 let joinButtonView;
@@ -39,7 +39,9 @@ async function onSubmitSuccess(json) {
         var key;
 
         try {
-            key = await GenerateAESGCM128KeyBase64();
+            var encrypter = new Encrypter(new AESGCM128());
+            await encrypter.setup();
+            key = ArrayBufferToBase64(encrypter.exportKey);
         } catch (e) {
             console.error('could not generate chat key', e);
             $("#result_link").html("error: could not generate chat encryption key");

--- a/static/js/chat/init.js
+++ b/static/js/chat/init.js
@@ -1,4 +1,5 @@
 import * as util from "/js/util.js";
+import {GenerateAESGCM128KeyBase64} from "/js/message/crypto.js";
 
 let copyButtonView;
 let joinButtonView;
@@ -25,7 +26,7 @@ function onSubmit(e) {
     });
 }
 
-function onSubmitSuccess(json) {
+async function onSubmitSuccess(json) {
     $("#loading").hide();
 
     $("#link_box").show();
@@ -35,7 +36,18 @@ function onSubmitSuccess(json) {
 
     if (json.code == 200) {
         var id = json.body.id;
-        var link = window.location.origin + '/html/joinchat.html?id=' + id
+        var key;
+
+        try {
+            key = await GenerateAESGCM128KeyBase64();
+        } catch (e) {
+            console.error('could not generate chat key', e);
+            $("#result_link").html("error: could not generate chat encryption key");
+            copyButtonView.style.display = "none";
+            return;
+        }
+
+        var link = window.location.origin + '/html/joinchat.html?id=' + id + '#key=' + encodeURIComponent(key);
         $('#result_link').html('<input id="to_copy" value="' + link + '">' + link + '</input>');
         joinButtonView.href = link;
         joinButtonView.style.display = "inline-flex";

--- a/static/js/message/crypto.js
+++ b/static/js/message/crypto.js
@@ -25,6 +25,52 @@ export class AESGCM128 extends EncryptionAlgorithm {
     }
 }
 
+export async function GenerateAESGCM128KeyBase64() {
+    const key = await crypto.subtle.generateKey(new AESGCM128().params, true, ['encrypt', 'decrypt']);
+    const exportedKey = await crypto.subtle.exportKey('raw', key);
+
+    return ArrayBufferToBase64(exportedKey);
+}
+
+export async function ImportAESGCM128Key(keyBase64) {
+    return crypto.subtle.importKey(
+        'raw',
+        Base64ToArrayBuffer(keyBase64),
+        new AESGCM128().params,
+        false,
+        ['encrypt', 'decrypt']
+    );
+}
+
+export async function EncryptStringWithAESGCM128Key(key, plaintext) {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv: iv },
+        key,
+        new TextEncoder().encode(plaintext)
+    );
+
+    return {
+        alg: 'AES-GCM-128',
+        iv: ArrayBufferToBase64(iv),
+        ciphertext: ArrayBufferToBase64(ciphertext),
+    };
+}
+
+export async function DecryptStringWithAESGCM128Key(key, payload) {
+    if (!payload || payload.alg !== 'AES-GCM-128' || !payload.iv || !payload.ciphertext) {
+        throw new Error('invalid encrypted payload');
+    }
+
+    const plaintext = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: Base64ToArrayBuffer(payload.iv) },
+        key,
+        Base64ToArrayBuffer(payload.ciphertext)
+    );
+
+    return new TextDecoder('utf-8').decode(plaintext);
+}
+
 export class Encrypter {
     #_algParams;
     #_encryptionParams;

--- a/static/js/message/crypto.js
+++ b/static/js/message/crypto.js
@@ -25,52 +25,6 @@ export class AESGCM128 extends EncryptionAlgorithm {
     }
 }
 
-export async function GenerateAESGCM128KeyBase64() {
-    const key = await crypto.subtle.generateKey(new AESGCM128().params, true, ['encrypt', 'decrypt']);
-    const exportedKey = await crypto.subtle.exportKey('raw', key);
-
-    return ArrayBufferToBase64(exportedKey);
-}
-
-export async function ImportAESGCM128Key(keyBase64) {
-    return crypto.subtle.importKey(
-        'raw',
-        Base64ToArrayBuffer(keyBase64),
-        new AESGCM128().params,
-        false,
-        ['encrypt', 'decrypt']
-    );
-}
-
-export async function EncryptStringWithAESGCM128Key(key, plaintext) {
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-    const ciphertext = await crypto.subtle.encrypt(
-        { name: 'AES-GCM', iv: iv },
-        key,
-        new TextEncoder().encode(plaintext)
-    );
-
-    return {
-        alg: 'AES-GCM-128',
-        iv: ArrayBufferToBase64(iv),
-        ciphertext: ArrayBufferToBase64(ciphertext),
-    };
-}
-
-export async function DecryptStringWithAESGCM128Key(key, payload) {
-    if (!payload || payload.alg !== 'AES-GCM-128' || !payload.iv || !payload.ciphertext) {
-        throw new Error('invalid encrypted payload');
-    }
-
-    const plaintext = await crypto.subtle.decrypt(
-        { name: 'AES-GCM', iv: Base64ToArrayBuffer(payload.iv) },
-        key,
-        Base64ToArrayBuffer(payload.ciphertext)
-    );
-
-    return new TextDecoder('utf-8').decode(plaintext);
-}
-
 export class Encrypter {
     #_algParams;
     #_encryptionParams;
@@ -90,6 +44,10 @@ export class Encrypter {
         this._encryptionParams.iv = crypto.getRandomValues(new Uint8Array(12));
     }
 
+    async setupWithKey(key) {
+        this._key = await crypto.subtle.importKey('raw', key, this._algParams, false, ['encrypt']);
+    }
+
     get exportKey() {
         return this._exportKey;
     }
@@ -106,6 +64,17 @@ export class Encrypter {
     // encryptBytes encrypts the given ArrayBuffer and returns the encrypted ArrayBuffer
     async encryptBytes(buf) {
         return await crypto.subtle.encrypt(this._encryptionParams, this._key, buf);
+    }
+
+    async encryptStringWithNewIV(s) {
+        this._encryptionParams.iv = crypto.getRandomValues(new Uint8Array(12));
+        const ciphertext = await this.encryptString(s);
+
+        return {
+            alg: 'AES-GCM-128',
+            iv: ArrayBufferToBase64(this.iv),
+            ciphertext: ArrayBufferToBase64(ciphertext),
+        };
     }
 }
 

--- a/ui-tests/tests/chat-flow.e2e.spec.js
+++ b/ui-tests/tests/chat-flow.e2e.spec.js
@@ -8,7 +8,7 @@ test("@e2e creates a temporary chat and exchanges messages over WebSocket", asyn
   await page.locator("button", { hasText: "Create chat" }).click();
 
   const linkInput = page.locator("#to_copy");
-  await expect(linkInput).toHaveValue(/\/html\/joinchat\.html\?id=.*/);
+  await expect(linkInput).toHaveValue(/\/html\/joinchat\.html\?id=.*#key=.*/);
   const chatLink = await linkInput.inputValue();
 
   const firstUserPage = await browser.newPage();

--- a/ui-tests/tests/chat-init.unit.spec.js
+++ b/ui-tests/tests/chat-init.unit.spec.js
@@ -17,9 +17,11 @@ test("@unit resets the copy button when a new chat link is generated", async ({
   page,
 }) => {
   let responseIndex = 0;
+  const initRequestBodies = [];
   const chatIDs = ["first-chat", "second-chat"];
 
   await page.route("**/api/v1/chat/init", async (route) => {
+    initRequestBodies.push(route.request().postData());
     const chatID = chatIDs[responseIndex];
     responseIndex += 1;
 
@@ -37,12 +39,17 @@ test("@unit resets the copy button when a new chat link is generated", async ({
   await page.goto("/html/initchat.html");
   await page.locator("button", { hasText: "Create chat" }).click();
 
-  await expect(page.locator("#to_copy")).toHaveValue(/first-chat/);
+  await expect(page.locator("#to_copy")).toHaveValue(
+    /\/html\/joinchat\.html\?id=first-chat#key=/
+  );
   await page.locator("#copy_button").click();
   await expect(page.locator("#copy_button")).toHaveText("Copied!");
 
   await page.locator("button", { hasText: "Create chat" }).click();
 
-  await expect(page.locator("#to_copy")).toHaveValue(/second-chat/);
+  await expect(page.locator("#to_copy")).toHaveValue(
+    /\/html\/joinchat\.html\?id=second-chat#key=/
+  );
   await expect(page.locator("#copy_button")).toHaveText("Copy link");
+  expect(initRequestBodies.join("\n")).not.toContain("key");
 });

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -109,6 +109,13 @@ async function openJoinChat(page) {
   await page.waitForFunction(() => Boolean(window.__technochatMockSocket));
 }
 
+async function openJoinChatScript(page) {
+  await page.goto(
+    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
+  );
+  await page.waitForFunction(() => typeof window.onfocus === "function");
+}
+
 test("@unit keeps the unread title until the tab receives focus", async ({
   page,
 }) => {
@@ -175,7 +182,7 @@ test("@unit does not blink the page title when the chat page is visible", async 
 test("@unit keeps the original title when focus returns before any unread notification", async ({
   page,
 }) => {
-  await openJoinChat(page);
+  await openJoinChatScript(page);
 
   await expect(page.locator("#chat-messages")).toBeVisible();
   await expect(page).toHaveTitle("TechnoChat");

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -1,7 +1,24 @@
 const { test, expect } = require("@playwright/test");
 
+const chatKeyBase64 = "AAAAAAAAAAAAAAAAAAAAAA==";
+
 function installJoinChatMocks() {
   let isHidden = false;
+
+  function base64ToArrayBuffer(value) {
+    const raw = atob(value);
+    const bytes = new Uint8Array(raw.length);
+
+    for (let i = 0; i < raw.length; i++) {
+      bytes[i] = raw.charCodeAt(i);
+    }
+
+    return bytes.buffer;
+  }
+
+  function arrayBufferToBase64(value) {
+    return btoa(String.fromCharCode(...new Uint8Array(value)));
+  }
 
   Object.defineProperty(Document.prototype, "hidden", {
     configurable: true,
@@ -57,6 +74,28 @@ function installJoinChatMocks() {
       data: JSON.stringify(payload),
     });
   };
+  window.__encryptJoinChatMessage = async (text) => {
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const key = await crypto.subtle.importKey(
+      "raw",
+      base64ToArrayBuffer(params.get("key")),
+      { name: "AES-GCM", length: 128 },
+      false,
+      ["encrypt"]
+    );
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      new TextEncoder().encode(text)
+    );
+
+    return {
+      alg: "AES-GCM-128",
+      iv: arrayBufferToBase64(iv),
+      ciphertext: arrayBufferToBase64(ciphertext),
+    };
+  };
 }
 
 test.beforeEach(async ({ page }) => {
@@ -64,7 +103,9 @@ test.beforeEach(async ({ page }) => {
 });
 
 async function openJoinChat(page) {
-  await page.goto("/html/joinchat.html?id=chat-id");
+  await page.goto(
+    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
+  );
   await page.waitForFunction(() => Boolean(window.__technochatMockSocket));
 }
 
@@ -76,12 +117,12 @@ test("@unit keeps the unread title until the tab receives focus", async ({
   await expect(page.locator("#chat-messages")).toBeVisible();
   await expect(page).toHaveTitle("TechnoChat");
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     window.__setJoinChatHiddenState(true);
     window.__emitJoinChatMessage({
       type: 1,
       username: "alice",
-      data: "hello from hidden tab",
+      data: await window.__encryptJoinChatMessage("hello from hidden tab"),
     });
   });
 
@@ -115,12 +156,12 @@ test("@unit does not blink the page title when the chat page is visible", async 
   await expect(page.locator("#chat-messages")).toBeVisible();
   await expect(page).toHaveTitle("TechnoChat");
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     window.__setJoinChatHiddenState(false);
     window.__emitJoinChatMessage({
       type: 1,
       username: "bob",
-      data: "visible message",
+      data: await window.__encryptJoinChatMessage("visible message"),
     });
   });
 
@@ -144,4 +185,69 @@ test("@unit keeps the original title when focus returns before any unread notifi
   });
 
   await expect(page).toHaveTitle("TechnoChat");
+});
+
+test("@unit encrypts outbound chat messages before WebSocket send", async ({
+  page,
+}) => {
+  await openJoinChat(page);
+
+  await page.evaluate(() => {
+    window.__emitJoinChatMessage({
+      type: 0,
+      data: {
+        event_id: 0,
+        event_data: "alice",
+      },
+    });
+  });
+
+  await page.locator('input[type="text"]').fill("server must not read this");
+  await page.locator('input[type="text"]').press("Enter");
+
+  const payload = await page.waitForFunction(() => {
+    const sent = window.__technochatMockSocket.lastSentPayload;
+
+    if (!sent) {
+      return false;
+    }
+
+    return JSON.parse(sent);
+  });
+  const sentMessage = await payload.jsonValue();
+
+  expect(JSON.stringify(sentMessage)).not.toContain("server must not read this");
+  expect(sentMessage.data.alg).toBe("AES-GCM-128");
+  expect(sentMessage.data.iv).toBeTruthy();
+  expect(sentMessage.data.ciphertext).toBeTruthy();
+
+  const decrypted = await page.evaluate(async (encryptedPayload) => {
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const keyBytes = Uint8Array.from(atob(params.get("key")), (char) =>
+      char.charCodeAt(0)
+    );
+    const key = await crypto.subtle.importKey(
+      "raw",
+      keyBytes,
+      { name: "AES-GCM", length: 128 },
+      false,
+      ["decrypt"]
+    );
+    const iv = Uint8Array.from(atob(encryptedPayload.iv), (char) =>
+      char.charCodeAt(0)
+    );
+    const ciphertext = Uint8Array.from(
+      atob(encryptedPayload.ciphertext),
+      (char) => char.charCodeAt(0)
+    );
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv },
+      key,
+      ciphertext
+    );
+
+    return new TextDecoder().decode(plain);
+  }, sentMessage.data);
+
+  expect(decrypted).toBe("server must not read this");
 });


### PR DESCRIPTION
## Summary

Closes #96.

Adds a first E2EE milestone for temporary chats:

- generate a browser-side AES-GCM-128 room key when creating a chat;
- carry the room key in the invite URL fragment (`#key=...`) so it is not sent to the server in HTTP/WebSocket requests;
- encrypt each outbound chat message in the browser with a fresh IV before `WebSocket.send`;
- decrypt chat messages only in the receiving browser;
- keep the Go chat server as a relay for ciphertext plus delivery metadata;
- document the encrypted chat transport model in `README.md`.

Also updates the lint toolchain to `golangci-lint` v2.11.4 and migrates `golangci.yml` to the v2 config format so lint runs cleanly with Go 1.26. The GitHub Actions lint job now uses `golangci/golangci-lint-action@v8` with the same `golangci-lint` binary version.

## Notes on security scope

This uses a shared symmetric room key carried in the invitation link. It prevents the server relay path from receiving readable user message bodies, but it does not add participant key authentication or forward secrecy. Server-generated service messages such as join/leave notifications remain plaintext metadata.
