### PR TITLE
Show chat message sent time

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -86,10 +86,12 @@ func (c *Chat) RestJoins() int {
 }
 
 func (c *Chat) SendServerNotify(str string) {
+	createdAt := time.Now().UTC()
 	msg := &message.WSMessage{
-		Type: message.WSMsgTypeMessage,
-		Name: "server",
-		Data: str,
+		Type:      message.WSMsgTypeMessage,
+		Name:      "server",
+		Data:      str,
+		CreatedAt: &createdAt,
 	}
 
 	if err := c.Broadcast(msg); err != nil {

--- a/internal/chat/message/message.go
+++ b/internal/chat/message/message.go
@@ -1,5 +1,7 @@
 package message
 
+import "time"
+
 type TypeID int
 
 const (
@@ -20,7 +22,8 @@ const (
 )
 
 type WSMessage struct {
-	Type TypeID      `json:"type"`
-	Data interface{} `json:"data"`
-	Name string      `json:"username"`
+	Type      TypeID      `json:"type"`
+	Data      interface{} `json:"data"`
+	Name      string      `json:"username"`
+	CreatedAt *time.Time  `json:"created_at,omitempty"`
 }

--- a/internal/chat/user.go
+++ b/internal/chat/user.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"log"
+	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -54,7 +55,9 @@ func (c *Chat) DelUser(id int) {
 func (c *Chat) SubscribeUser(usr *user.User) {
 	go func() {
 		for msg := range usr.ReadStream() {
+			createdAt := time.Now().UTC()
 			msg.Name = usr.Name
+			msg.CreatedAt = &createdAt
 			c.incomingChan <- msg
 		}
 	}()

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -98,6 +98,25 @@ button {
 .chat-message--own {
   align-items: flex-end;
 }
+
+.chat-message_meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+}
+
+.chat-message--own .chat-message_meta {
+  flex-direction: row-reverse;
+}
+
+.chat-message_time {
+  color: #6d6d6d;
+  flex: none;
+  font-size: 13px;
+  line-height: 1;
+}
+
 .chat-message .chip {
   display: inline-flex;
   align-items: center;

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -3,6 +3,7 @@
 
 html {
   background: #dddddd;
+  height: 100%;
 }
 
 body {
@@ -10,9 +11,11 @@ body {
   background:
     radial-gradient(circle at top, #dddddd 0%, #dddddd 38%, #d1d1d1 100%);
   margin: 0;
+  height: 100%;
   min-height: 100vh;
   min-height: 100dvh;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 input,
@@ -21,12 +24,13 @@ button {
 }
 
 .wrapper {
-  min-height: 100vh;
-  min-height: 100dvh;
+  height: 100vh;
+  height: 100dvh;
   padding: max(24px, env(safe-area-inset-top)) 20px max(32px, env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 .wrapper .header {

--- a/static/js/chat/chat.js
+++ b/static/js/chat/chat.js
@@ -130,9 +130,12 @@ new Vue({
 
             var ownMessageClass = this.isOwnMessage(username) ? ' chat-message--own' : '';
             this.chatContent += '<div class="chat-message' + ownMessageClass + '">'
-                + '<div class="chip" >'
+                + '<div class="chat-message_meta">'
+                + '<div class="chip">'
                 + this.avatarMarkup(username)
                 + this.escapeHtml(username)
+                + '</div>'
+                + this.messageTimeMarkup(msg.created_at)
                 + '</div>'
                 + '<div class="chat-message_body">'
                 + emojione.toImage(this.escapeHtml(body))
@@ -194,6 +197,20 @@ new Vue({
         },
         isOwnMessage: function(username) {
             return Boolean(this.name) && username === this.name;
+        },
+        messageTimeMarkup: function(createdAt) {
+            if (!createdAt) {
+                return '';
+            }
+
+            var sentAt = new Date(createdAt);
+            if (Number.isNaN(sentAt.getTime())) {
+                return '';
+            }
+
+            return '<time class="chat-message_time" datetime="' + sentAt.toISOString() + '">'
+                + this.escapeHtml(sentAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }))
+                + '</time>';
         },
     }
 });

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -1,6 +1,23 @@
 const { test, expect } = require("@playwright/test");
+const path = require("path");
 
 const chatKeyBase64 = "AAAAAAAAAAAAAAAAAAAAAA==";
+
+async function routeJoinChatWorktreeStatic(page) {
+  await page.route("**/html/joinchat.html**", async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      path: path.join(__dirname, "../../static/html/joinchat.html"),
+    });
+  });
+
+  await page.route("**/js/chat/chat.js**", async (route) => {
+    await route.fulfill({
+      contentType: "application/javascript",
+      path: path.join(__dirname, "../../static/js/chat/chat.js"),
+    });
+  });
+}
 
 function installJoinChatMocks() {
   let isHidden = false;
@@ -103,6 +120,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 async function openJoinChat(page) {
+  await routeJoinChatWorktreeStatic(page);
   await page.goto(
     `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
   );
@@ -110,6 +128,7 @@ async function openJoinChat(page) {
 }
 
 async function openJoinChatScript(page) {
+  await routeJoinChatWorktreeStatic(page);
   await page.goto(
     `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
   );
@@ -168,6 +187,7 @@ test("@unit does not blink the page title when the chat page is visible", async 
     window.__emitJoinChatMessage({
       type: 1,
       username: "bob",
+      created_at: "2026-05-01T06:07:08Z",
       data: await window.__encryptJoinChatMessage("visible message"),
     });
   });
@@ -177,6 +197,12 @@ test("@unit does not blink the page title when the chat page is visible", async 
   await expect(page).toHaveTitle("TechnoChat");
   await expect(page.locator("#chat-messages")).toContainText("bob");
   await expect(page.locator("#chat-messages")).toContainText("visible message");
+  await expect(page.locator(".chat-message_time")).toBeVisible();
+  await expect(page.locator(".chat-message_time")).toHaveAttribute(
+    "datetime",
+    "2026-05-01T06:07:08.000Z"
+  );
+  await expect(page.locator(".chat-message_time")).not.toBeEmpty();
 });
 
 test("@unit keeps the original title when focus returns before any unread notification", async ({

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -17,6 +17,13 @@ async function routeJoinChatWorktreeStatic(page) {
       path: path.join(__dirname, "../../static/js/chat/chat.js"),
     });
   });
+
+  await page.route("**/css/chat.css**", async (route) => {
+    await route.fulfill({
+      contentType: "text/css",
+      path: path.join(__dirname, "../../static/css/chat.css"),
+    });
+  });
 }
 
 function installJoinChatMocks() {
@@ -203,6 +210,48 @@ test("@unit does not blink the page title when the chat page is visible", async 
     "2026-05-01T06:07:08.000Z"
   );
   await expect(page.locator(".chat-message_time")).not.toBeEmpty();
+});
+
+test("@unit keeps chat input fixed while messages scroll internally", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await openJoinChat(page);
+
+  await page.evaluate(async () => {
+    window.__setJoinChatHiddenState(false);
+
+    for (let i = 0; i < 20; i++) {
+      window.__emitJoinChatMessage({
+        type: 1,
+        username: "Axe",
+        created_at: "2026-05-01T06:07:08Z",
+        data: await window.__encryptJoinChatMessage("Hi"),
+      });
+    }
+  });
+
+  const layout = await page.evaluate(() => {
+    const messages = document.getElementById("chat-messages");
+    const input = document.querySelector(".message_input");
+    const inputRect = input.getBoundingClientRect();
+
+    return {
+      bodyScrollHeight: document.documentElement.scrollHeight,
+      viewportHeight: window.innerHeight,
+      messagesClientHeight: messages.clientHeight,
+      messagesScrollHeight: messages.scrollHeight,
+      inputBottom: inputRect.bottom,
+    };
+  });
+
+  expect(layout.bodyScrollHeight).toBeLessThanOrEqual(
+    layout.viewportHeight + 1
+  );
+  expect(layout.messagesScrollHeight).toBeGreaterThan(
+    layout.messagesClientHeight
+  );
+  expect(layout.inputBottom).toBeLessThanOrEqual(layout.viewportHeight);
 });
 
 test("@unit keeps the original title when focus returns before any unread notification", async ({


### PR DESCRIPTION
## Summary

- add a server-side `created_at` timestamp to chat WebSocket messages and server notifications
- render the sent time next to the chat message author as secondary metadata
- keep the chat viewport fixed so long message lists scroll inside the message panel while the input stays visible
- extend chat unit coverage for both timestamp rendering and mobile overflow layout

## Why

Chat messages should show the time they were sent without taking much visual space. Using the server timestamp keeps the displayed time consistent for all participants instead of depending on each browser's receive/render time.

The chat page also needs to keep the input available when the room has many messages; the message list should own the scroll instead of growing the whole document.

closes #16

## Validation

- `make go-tests`
- `make lint`
- `make ui-unit-tests`