### PR TITLE
Add chat presence indicator

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -18,7 +19,8 @@ const (
 	MinPeopleInChat  = 2
 	MaxPeopleInChat  = 100
 
-	ChatAFKLifetime time.Duration = 12 * time.Hour
+	ChatAFKLifetime       time.Duration = 12 * time.Hour
+	PresenceBroadcastRate time.Duration = 30 * time.Second
 )
 
 const (
@@ -47,6 +49,7 @@ type Chat struct {
 	broadcastChan chan *message.WSMessage
 
 	restJoins  int // how many available invitations are left
+	maxUsers   int
 	corresps   map[int]*user.User
 	correspsMx sync.RWMutex
 }
@@ -63,6 +66,7 @@ func NewChat(opts NewChatOpts) *Chat {
 		incomingChan:         make(chan *message.WSMessage, incomingBufferSize),
 		broadcastChan:        make(chan *message.WSMessage, broadcastBufferSize),
 		restJoins:            opts.MaxJoins,
+		maxUsers:             opts.MaxJoins,
 		ChatNames:            NewChatNames(),
 		triggerShutdownChan:  make(chan struct{}),
 		shutdownChan:         make(chan struct{}),
@@ -94,6 +98,45 @@ func (c *Chat) SendServerNotify(str string) {
 
 	if err := c.Broadcast(msg); err != nil {
 		log.Printf("error: chat: could not send server notification in chat %s: %v", c.ID, err)
+	}
+}
+
+func (c *Chat) Presence() message.Presence {
+	c.correspsMx.RLock()
+	defer c.correspsMx.RUnlock()
+
+	users := make([]message.PresenceUser, 0, len(c.corresps))
+	for _, usr := range c.corresps {
+		users = append(users, message.PresenceUser{
+			ID:   usr.ID,
+			Name: usr.Name,
+		})
+	}
+
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].ID < users[j].ID
+	})
+
+	return message.Presence{
+		Online: len(users),
+		Max:    c.maxUsers,
+		Users:  users,
+	}
+}
+
+func (c *Chat) PresenceMessage() *message.WSMessage {
+	return &message.WSMessage{
+		Type: message.WSMsgTypeService,
+		Data: message.Event{
+			EventID:   message.EventPresence,
+			EventData: c.Presence(),
+		},
+	}
+}
+
+func (c *Chat) BroadcastPresence() {
+	if err := c.Broadcast(c.PresenceMessage()); err != nil {
+		log.Printf("error: chat: could not send presence update in chat %s: %v", c.ID, err)
 	}
 }
 
@@ -140,11 +183,13 @@ func (c *Chat) handleUsers() {
 
 			c.SubscribeUser(newUser)
 			c.SendServerNotify("user " + newUser.Name + " has joined")
+			c.BroadcastPresence()
 
 		case disconnectedUser := <-c.userDisconnectedChan:
 			c.SendServerNotify("user " + disconnectedUser.Name + " has left")
+			c.BroadcastPresence()
 
-			if len(c.corresps) == 0 && c.restJoins == 0 {
+			if c.Presence().Online == 0 && c.RestJoins() == 0 {
 				log.Printf("info: chat: no users left in chat %s", c.ID)
 				c.TriggerShutdown()
 			}
@@ -155,6 +200,9 @@ func (c *Chat) handleUsers() {
 func (c *Chat) handleCommunication() {
 	defer c.WG.Done()
 
+	presenceTicker := time.NewTicker(PresenceBroadcastRate)
+	defer presenceTicker.Stop()
+
 	for {
 		afkTimer := time.NewTimer(ChatAFKLifetime)
 
@@ -164,6 +212,9 @@ func (c *Chat) handleCommunication() {
 
 		case msg := <-c.broadcastChan:
 			c.broadcast(msg)
+
+		case <-presenceTicker.C:
+			c.broadcast(c.PresenceMessage())
 
 		case <-c.shutdownChan:
 			log.Printf("info: chat: closing communication goroutine for chat [%s]", c.ID)

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -1,6 +1,16 @@
 package chat
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"technochat/internal/chat/message"
+)
 
 func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
 	c := NewChat(NewChatOpts{
@@ -28,4 +38,100 @@ func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
 	if len(presence.Users) != 0 {
 		t.Fatalf("expected empty users list, got %d users", len(presence.Users))
 	}
+}
+
+func TestConnectBroadcastsPresenceEvent(t *testing.T) {
+	c := NewChat(NewChatOpts{
+		ID:       "presence-broadcast-test",
+		MaxJoins: 3,
+	})
+
+	done := make(chan struct{})
+	go func() {
+		c.Routine()
+		close(done)
+	}()
+	defer func() {
+		c.TriggerShutdown()
+		<-done
+	}()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := Upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("could not upgrade websocket: %v", err)
+			return
+		}
+
+		usr, err := c.AddUser(ws)
+		if err != nil {
+			t.Errorf("could not add user: %v", err)
+			_ = ws.Close()
+			return
+		}
+
+		usr.Routine()
+		c.DelUser(usr.ID)
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("could not dial websocket: %v", err)
+	}
+	defer client.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	if err := client.SetReadDeadline(deadline); err != nil {
+		t.Fatalf("could not set read deadline: %v", err)
+	}
+
+	for time.Now().Before(deadline) {
+		var wsMsg message.WSMessage
+		if err := client.ReadJSON(&wsMsg); err != nil {
+			t.Fatalf("could not read websocket message: %v", err)
+		}
+
+		event, ok := wsMsg.Data.(map[string]interface{})
+		if wsMsg.Type != message.WSMsgTypeService || !ok {
+			continue
+		}
+
+		if eventID, ok := event["event_id"].(float64); !ok || message.EventID(eventID) != message.EventPresence {
+			continue
+		}
+
+		presence, ok := event["event_data"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected presence event data, got %#v", event["event_data"])
+		}
+
+		if online := int(presence["online"].(float64)); online != 1 {
+			t.Fatalf("expected 1 online user, got %d", online)
+		}
+		if maxUsers := int(presence["max"].(float64)); maxUsers != 3 {
+			t.Fatalf("expected max users 3, got %d", maxUsers)
+		}
+
+		users, ok := presence["users"].([]interface{})
+		if !ok {
+			t.Fatalf("expected users list, got %#v", presence["users"])
+		}
+		if len(users) != 1 {
+			t.Fatalf("expected 1 user, got %d", len(users))
+		}
+
+		userData, ok := users[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected user object, got %#v", users[0])
+		}
+		if userData["name"] == "" {
+			t.Fatalf("expected user name in presence event")
+		}
+
+		return
+	}
+
+	t.Fatalf("timed out waiting for presence event")
 }

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,12 @@ import (
 
 	"technochat/internal/chat/message"
 )
+
+type testPresence struct {
+	Online int
+	Max    int
+	Users  []map[string]interface{}
+}
 
 func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
 	c := NewChat(NewChatOpts{
@@ -46,14 +53,63 @@ func TestConnectBroadcastsPresenceEvent(t *testing.T) {
 		MaxJoins: 3,
 	})
 
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChat(c, done)
+
+	client := dialTestChat(t, server)
+	defer client.Close()
+
+	presence := readPresenceEvent(t, client, 1)
+	if presence.Max != 3 {
+		t.Fatalf("expected max users 3, got %d", presence.Max)
+	}
+	if len(presence.Users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(presence.Users))
+	}
+	if presence.Users[0]["name"] == "" {
+		t.Fatalf("expected user name in presence event")
+	}
+}
+
+func TestDisconnectBroadcastsPresenceEvent(t *testing.T) {
+	c := NewChat(NewChatOpts{
+		ID:       "presence-disconnect-test",
+		MaxJoins: 3,
+	})
+
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChat(c, done)
+
+	firstClient := dialTestChat(t, server)
+	defer firstClient.Close()
+	readPresenceEvent(t, firstClient, 1)
+
+	secondClient := dialTestChat(t, server)
+	defer secondClient.Close()
+	readPresenceEvent(t, firstClient, 2)
+
+	if err := secondClient.Close(); err != nil {
+		t.Fatalf("could not close second client: %v", err)
+	}
+
+	presence := readPresenceEvent(t, firstClient, 1)
+	if presence.Max != 3 {
+		t.Fatalf("expected max users 3, got %d", presence.Max)
+	}
+	if len(presence.Users) != 1 {
+		t.Fatalf("expected 1 remaining user, got %d", len(presence.Users))
+	}
+}
+
+func serveTestChat(t *testing.T, c *Chat) (*httptest.Server, chan struct{}) {
+	t.Helper()
+
 	done := make(chan struct{})
 	go func() {
 		c.Routine()
 		close(done)
-	}()
-	defer func() {
-		c.TriggerShutdown()
-		<-done
 	}()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -73,14 +129,29 @@ func TestConnectBroadcastsPresenceEvent(t *testing.T) {
 		usr.Routine()
 		c.DelUser(usr.ID)
 	}))
-	defer server.Close()
+
+	return server, done
+}
+
+func stopTestChat(c *Chat, done chan struct{}) {
+	c.TriggerShutdown()
+	<-done
+}
+
+func dialTestChat(t *testing.T, server *httptest.Server) *websocket.Conn {
+	t.Helper()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
 	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("could not dial websocket: %v", err)
 	}
-	defer client.Close()
+
+	return client
+}
+
+func readPresenceEvent(t *testing.T, client *websocket.Conn, expectedOnline int) testPresence {
+	t.Helper()
 
 	deadline := time.Now().Add(2 * time.Second)
 	if err := client.SetReadDeadline(deadline); err != nil {
@@ -88,50 +159,74 @@ func TestConnectBroadcastsPresenceEvent(t *testing.T) {
 	}
 
 	for time.Now().Before(deadline) {
-		var wsMsg message.WSMessage
-		if err := client.ReadJSON(&wsMsg); err != nil {
-			t.Fatalf("could not read websocket message: %v", err)
-		}
-
-		event, ok := wsMsg.Data.(map[string]interface{})
-		if wsMsg.Type != message.WSMsgTypeService || !ok {
+		presence, ok := readNextPresenceEvent(t, client)
+		if !ok {
 			continue
 		}
 
-		if eventID, ok := event["event_id"].(float64); !ok || message.EventID(eventID) != message.EventPresence {
-			continue
+		if presence.Online == expectedOnline {
+			return presence
 		}
-
-		presence, ok := event["event_data"].(map[string]interface{})
-		if !ok {
-			t.Fatalf("expected presence event data, got %#v", event["event_data"])
-		}
-
-		if online := int(presence["online"].(float64)); online != 1 {
-			t.Fatalf("expected 1 online user, got %d", online)
-		}
-		if maxUsers := int(presence["max"].(float64)); maxUsers != 3 {
-			t.Fatalf("expected max users 3, got %d", maxUsers)
-		}
-
-		users, ok := presence["users"].([]interface{})
-		if !ok {
-			t.Fatalf("expected users list, got %#v", presence["users"])
-		}
-		if len(users) != 1 {
-			t.Fatalf("expected 1 user, got %d", len(users))
-		}
-
-		userData, ok := users[0].(map[string]interface{})
-		if !ok {
-			t.Fatalf("expected user object, got %#v", users[0])
-		}
-		if userData["name"] == "" {
-			t.Fatalf("expected user name in presence event")
-		}
-
-		return
 	}
 
-	t.Fatalf("timed out waiting for presence event")
+	t.Fatalf("timed out waiting for presence event with %d online users", expectedOnline)
+
+	return testPresence{}
+}
+
+func readNextPresenceEvent(t *testing.T, client *websocket.Conn) (testPresence, bool) {
+	t.Helper()
+
+	var wsMsg message.WSMessage
+	if err := client.ReadJSON(&wsMsg); err != nil {
+		t.Fatalf("could not read websocket message: %v", err)
+	}
+
+	event, ok := wsMsg.Data.(map[string]interface{})
+	if wsMsg.Type != message.WSMsgTypeService || !ok {
+		return testPresence{}, false
+	}
+
+	eventID, ok := event["event_id"].(float64)
+	if !ok || message.EventID(eventID) != message.EventPresence {
+		return testPresence{}, false
+	}
+
+	eventData, ok := event["event_data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected presence event data, got %#v", event["event_data"])
+	}
+
+	users, ok := eventData["users"].([]interface{})
+	if !ok {
+		t.Fatalf("expected users list, got %#v", eventData["users"])
+	}
+
+	presence := testPresence{
+		Online: int(numberFromPresenceEvent(t, eventData, "online")),
+		Max:    int(numberFromPresenceEvent(t, eventData, "max")),
+		Users:  make([]map[string]interface{}, 0, len(users)),
+	}
+
+	for _, rawUser := range users {
+		userData, ok := rawUser.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected user object, got %#v", rawUser)
+		}
+
+		presence.Users = append(presence.Users, userData)
+	}
+
+	return presence, true
+}
+
+func numberFromPresenceEvent(t *testing.T, eventData map[string]interface{}, field string) float64 {
+	t.Helper()
+
+	value, ok := eventData[field].(float64)
+	if !ok {
+		t.Fatalf("expected numeric presence field %q, got %s", field, fmt.Sprintf("%#v", eventData[field]))
+	}
+
+	return value
 }

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -58,7 +58,7 @@ func TestConnectBroadcastsPresenceEvent(t *testing.T) {
 	defer stopTestChat(c, done)
 
 	client := dialTestChat(t, server)
-	defer client.Close()
+	defer closeTestClient(t, client)
 
 	presence := readPresenceEvent(t, client, 1)
 	if presence.Max != 3 {
@@ -83,11 +83,10 @@ func TestDisconnectBroadcastsPresenceEvent(t *testing.T) {
 	defer stopTestChat(c, done)
 
 	firstClient := dialTestChat(t, server)
-	defer firstClient.Close()
+	defer closeTestClient(t, firstClient)
 	readPresenceEvent(t, firstClient, 1)
 
 	secondClient := dialTestChat(t, server)
-	defer secondClient.Close()
 	readPresenceEvent(t, firstClient, 2)
 
 	if err := secondClient.Close(); err != nil {
@@ -148,6 +147,14 @@ func dialTestChat(t *testing.T, server *httptest.Server) *websocket.Conn {
 	}
 
 	return client
+}
+
+func closeTestClient(t *testing.T, client *websocket.Conn) {
+	t.Helper()
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("could not close websocket client: %v", err)
+	}
 }
 
 func readPresenceEvent(t *testing.T, client *websocket.Conn, expectedOnline int) testPresence {

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -1,0 +1,31 @@
+package chat
+
+import "testing"
+
+func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
+	c := NewChat(NewChatOpts{
+		ID:       "presence-test",
+		MaxJoins: 5,
+	})
+
+	done := make(chan struct{})
+	go func() {
+		c.Routine()
+		close(done)
+	}()
+	defer func() {
+		c.TriggerShutdown()
+		<-done
+	}()
+
+	presence := c.Presence()
+	if presence.Online != 0 {
+		t.Fatalf("expected no online users, got %d", presence.Online)
+	}
+	if presence.Max != 5 {
+		t.Fatalf("expected max users 5, got %d", presence.Max)
+	}
+	if len(presence.Users) != 0 {
+		t.Fatalf("expected empty users list, got %d users", len(presence.Users))
+	}
+}

--- a/internal/chat/message/message.go
+++ b/internal/chat/message/message.go
@@ -17,10 +17,22 @@ const (
 	EventConnInitOk EventID = iota
 	EventConnInitNoSuchChat
 	EventConnInitMaxUsrsReached
+	EventPresence
 )
 
 type WSMessage struct {
 	Type TypeID      `json:"type"`
 	Data interface{} `json:"data"`
 	Name string      `json:"username"`
+}
+
+type PresenceUser struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type Presence struct {
+	Online int            `json:"online"`
+	Max    int            `json:"max"`
+	Users  []PresenceUser `json:"users"`
 }

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -66,6 +66,142 @@ button {
   min-height: 0;
 }
 
+.presence_bar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.presence_button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 6px 14px;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.82);
+  color: #111111;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1.2;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.presence_button:hover {
+  transform: translateY(-1px);
+  background: #ffffff;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.12);
+}
+
+.presence_button:focus {
+  outline: 2px solid #111111;
+  outline-offset: 2px;
+}
+
+.presence_modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: max(72px, env(safe-area-inset-top)) 16px max(18px, env(safe-area-inset-bottom));
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.presence_panel {
+  width: min(360px, 100%);
+  max-height: min(430px, 72vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111111;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.22);
+}
+
+.presence_header {
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px 0 18px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+  flex-shrink: 0;
+}
+
+.presence_header h2 {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.presence_close {
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #111111;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.presence_close:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.presence_close:focus {
+  outline: 2px solid #111111;
+  outline-offset: 2px;
+}
+
+.presence_list {
+  max-height: min(360px, 60vh);
+  overflow-y: auto;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.presence_user {
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  box-sizing: border-box;
+}
+
+.presence_user + .presence_user {
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.presence_user img {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  background: #ffffff;
+  flex-shrink: 0;
+}
+
+.presence_user span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 20px;
+}
+
 .chat_content {
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(0, 0, 0, 0.1);
@@ -251,6 +387,30 @@ input:focus ~ .bar:after {
   .wrapper .header .logo h1 {
     font-size: 28px;
     line-height: 1.4;
+  }
+
+  .presence_bar {
+    justify-content: center;
+  }
+
+  .presence_button {
+    width: 100%;
+    min-height: 42px;
+    font-size: 17px;
+  }
+
+  .presence_modal {
+    align-items: flex-end;
+    padding: max(12px, env(safe-area-inset-top)) 10px max(12px, env(safe-area-inset-bottom));
+  }
+
+  .presence_panel {
+    width: 100%;
+    max-height: min(380px, 68vh);
+  }
+
+  .presence_list {
+    max-height: min(320px, 55vh);
   }
 
   .chat_messages {

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -63,6 +63,7 @@ button {
 }
 
 .chat_shell {
+  position: relative;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -71,6 +72,10 @@ button {
 }
 
 .presence_bar {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  z-index: 8;
   display: flex;
   justify-content: flex-end;
 }
@@ -413,13 +418,14 @@ input:focus ~ .bar:after {
   }
 
   .presence_bar {
-    justify-content: center;
+    top: 10px;
+    right: 10px;
   }
 
   .presence_button {
-    width: 100%;
-    min-height: 42px;
-    font-size: 17px;
+    min-height: 34px;
+    padding: 5px 10px;
+    font-size: 15px;
   }
 
   .presence_modal {

--- a/static/html/joinchat.html
+++ b/static/html/joinchat.html
@@ -27,6 +27,17 @@
         </div>
         <div class="main" id="app">
             <div v-if="okconnected" class="chat_shell">
+                <div class="presence_bar">
+                    <button
+                        class="presence_button"
+                        type="button"
+                        @click="openPresence"
+                        aria-haspopup="dialog"
+                        :aria-expanded="presenceOpen ? 'true' : 'false'"
+                    >
+                        {{ presenceLabel }}
+                    </button>
+                </div>
                 <div class="chat_content">
                     <div id="chat-messages" class="chat_messages" v-html="chatContent"></div>
                 </div>
@@ -42,6 +53,34 @@
                         <button class="chat_button" @click="send" aria-label="Send message">
                             <i class="material-icons">send</i>
                         </button>
+                    </div>
+                </div>
+                <div
+                    v-if="presenceOpen"
+                    class="presence_modal"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="presence_title"
+                    @click.self="closePresence"
+                >
+                    <div class="presence_panel">
+                        <div class="presence_header">
+                            <h2 id="presence_title">Online users</h2>
+                            <button class="presence_close" type="button" @click="closePresence" aria-label="Close">
+                                <i class="material-icons">close</i>
+                            </button>
+                        </div>
+                        <div class="presence_list">
+                            <div v-for="user in presence.users" :key="user.id" class="presence_user">
+                                <img
+                                    :src="roboHash(user.name)"
+                                    :alt="user.name"
+                                    loading="lazy"
+                                    @error="useFallbackAvatar($event, user.name)"
+                                >
+                                <span>{{ user.name }}</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/static/js/chat/chat.js
+++ b/static/js/chat/chat.js
@@ -11,6 +11,7 @@ const WSMsgTypeMessage = 1;
 const EventConnInitOk = 0;
 const EventConnInitNoSuchChat = 1;
 const EventConnInitMaxUsrsReached = 2;
+const EventPresence = 3;
 
 const NewMsgTitle = "New message!";
 
@@ -33,6 +34,17 @@ new Vue({
         newMessagesNum: 0,
         roomKey: '',
         encrypter: null,
+        presence: {
+            online: 0,
+            max: 0,
+            users: [],
+        },
+        presenceOpen: false,
+    },
+    computed: {
+        presenceLabel: function() {
+            return this.presence.online + ' (' + this.presence.max + ') online';
+        },
     },
     created: function() {
         var id = getParameterByName('id', window.location);
@@ -76,6 +88,9 @@ new Vue({
                         }
                         if (msg.data.event_id == EventConnInitNoSuchChat || msg.data.event_id == EventConnInitMaxUsrsReached ){
                             self.okconnected = false;
+                        }
+                        if (msg.data.event_id == EventPresence) {
+                            self.updatePresence(msg.data.event_data);
                         }
                         break;
                     case WSMsgTypeMessage:
@@ -171,6 +186,26 @@ new Vue({
                 element.scrollTop = element.scrollHeight;
             });
         },
+        updatePresence: function(data) {
+            var users = Array.isArray(data && data.users) ? data.users : [];
+
+            this.presence = {
+                online: Number(data && data.online) || users.length,
+                max: Number(data && data.max) || 0,
+                users: users.map(function(user) {
+                    return {
+                        id: user.id,
+                        name: String(user.name || ''),
+                    };
+                }),
+            };
+        },
+        openPresence: function() {
+            this.presenceOpen = true;
+        },
+        closePresence: function() {
+            this.presenceOpen = false;
+        },
         avatarMarkup: function(username) {
             var safeUsername = this.escapeHtml(username);
             var fallback = this.fallbackAvatar(username);
@@ -188,6 +223,10 @@ new Vue({
                 + 'font-family="Ubuntu Mono, monospace" font-size="22" fill="#ffffff">' + letter + '</text>'
                 + '</svg>';
             return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
+        },
+        useFallbackAvatar: function(event, username) {
+            event.target.onerror = null;
+            event.target.src = this.fallbackAvatar(username);
         },
         escapeHtml: function(value) {
             return $('<div>').text(value == null ? '' : String(value)).html();

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -258,3 +258,42 @@ test("@unit encrypts outbound chat messages before WebSocket send", async ({
 
   expect(decrypted).toBe("server must not read this");
 });
+
+test("@unit shows online count and scrollable online users popup", async ({
+  page,
+}) => {
+  await openJoinChat(page);
+
+  await page.evaluate(() => {
+    window.__emitJoinChatMessage({
+      type: 0,
+      data: {
+        event_id: 3,
+        event_data: {
+          online: 4,
+          max: 8,
+          users: [
+            { id: 1, name: "Abaddon" },
+            { id: 2, name: "Lina" },
+            { id: 3, name: "Pudge" },
+            { id: 4, name: "Crystal Maiden" },
+          ],
+        },
+      },
+    });
+  });
+
+  await expect(page.locator(".presence_button")).toHaveText("4 (8) online");
+
+  await page.locator(".presence_button").click();
+
+  const popup = page.locator(".presence_panel");
+  await expect(popup).toBeVisible();
+  await expect(popup.locator(".presence_user")).toHaveCount(4);
+  await expect(popup).toContainText("Crystal Maiden");
+
+  const overflowY = await page.locator(".presence_list").evaluate((element) => {
+    return window.getComputedStyle(element).overflowY;
+  });
+  expect(overflowY).toBe("auto");
+});


### PR DESCRIPTION
Adds an online presence indicator to chat rooms.

- broadcasts a presence snapshot with online count, configured chat quota, and online users
- refreshes presence immediately on connect/disconnect and every 30 seconds
- shows `N (M) online` in the chat UI and opens a fixed-size scrollable popup with user avatars
- covers the server snapshot and UI popup behavior with focused tests

Checked with `GOCACHE=/Users/kirill.alekseev/Разработка/dev/technochat-issue-17-chat-presence/.cache/go-build make go-tests`, `golangci-lint run -v -c golangci.yml --new-from-rev=master` using `/private/tmp` caches, `node --check static/js/chat/chat.js`, and `git diff --check`.

closes #17
