### PR TITLE
Add isolated test environment

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,8 +49,30 @@ jobs:
     - name: Install Playwright browsers
       run: npm --prefix ui-tests exec playwright install chromium webkit
 
+    - name: Make deploy.sh executable
+      run: chmod +x ./deploy.sh
+
     - name: Run smoke tests
-      run: make smoke-tests
+      run: ./deploy.sh --dev
+
+    - name: Wait for HTTPS server to respond on /
+      run: |
+        for i in {1..10}; do
+          if curl -kfs https://localhost/; then
+            echo "HTTPS server is up"
+            exit 0
+          fi
+          echo "Waiting for HTTPS server..."
+          sleep 3
+        done
+        echo "::error ::HTTPS server not responding after deploy"
+        exit 1
+
+    - name: Dump container diagnostics on failure
+      if: failure()
+      run: |
+        docker compose -f dist/docker-compose.yml -f dist/docker-compose-dev.yml ps
+        docker compose -f dist/docker-compose.yml -f dist/docker-compose-dev.yml logs --no-color
 
     - name: Run Go tests
       run: make go-tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,16 +50,16 @@ jobs:
       run: npm --prefix ui-tests exec playwright install chromium webkit
 
     - name: Run smoke tests
-      run: dist/run-isolated-tests.sh -- true
+      run: make smoke-tests
 
     - name: Run Go tests
       run: make go-tests
 
     - name: Run integration tests
-      run: dist/run-isolated-tests.sh -- make integration-tests
+      run: make integration-tests
 
     - name: Run UI unit tests
-      run: dist/run-isolated-tests.sh -- make ui-unit-tests
+      run: make ui-unit-tests
 
     - name: Run UI end-to-end tests
-      run: dist/run-isolated-tests.sh -- make ui-e2e-tests
+      run: make ui-e2e-tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,16 +50,16 @@ jobs:
       run: npm --prefix ui-tests exec playwright install chromium webkit
 
     - name: Run smoke tests
-      run: make test TEST_COMMAND=true
+      run: dist/run-isolated-tests.sh -- true
 
     - name: Run Go tests
       run: make go-tests
 
     - name: Run integration tests
-      run: make test TEST_COMMAND='make integration-tests'
+      run: dist/run-isolated-tests.sh -- make integration-tests
 
     - name: Run UI unit tests
-      run: make test TEST_COMMAND='make ui-unit-tests'
+      run: dist/run-isolated-tests.sh -- make ui-unit-tests
 
     - name: Run UI end-to-end tests
-      run: make test TEST_COMMAND='make ui-e2e-tests'
+      run: dist/run-isolated-tests.sh -- make ui-e2e-tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,36 +49,17 @@ jobs:
     - name: Install Playwright browsers
       run: npm --prefix ui-tests exec playwright install chromium webkit
 
-    - name: Make deploy.sh executable
-      run: chmod +x ./deploy.sh
-
     - name: Run smoke tests
-      run: ./deploy.sh --dev
+      run: make test TEST_COMMAND=true
 
-    - name: Wait for HTTPS server to respond on /
-      run: |
-        for i in {1..10}; do
-          if curl -kfs https://localhost/; then
-            echo "HTTPS server is up"
-            exit 0
-          fi
-          echo "Waiting for HTTPS server..."
-          sleep 3
-        done
-        echo "::error ::HTTPS server not responding after deploy"
-        exit 1
+    - name: Run Go tests
+      run: make go-tests
 
-    - name: Dump container diagnostics on failure
-      if: failure()
-      run: |
-        docker compose -f dist/docker-compose-dev.yml ps
-        docker compose -f dist/docker-compose-dev.yml logs --no-color
+    - name: Run integration tests
+      run: make test TEST_COMMAND='make integration-tests'
 
-    - name: Run all tests
-      run: make test
+    - name: Run UI unit tests
+      run: make test TEST_COMMAND='make ui-unit-tests'
 
-    - name: Dump container diagnostics on failure
-      if: failure()
-      run: |
-        docker compose -f dist/docker-compose-dev.yml ps
-        docker compose -f dist/docker-compose-dev.yml logs --no-color
+    - name: Run UI end-to-end tests
+      run: make test TEST_COMMAND='make ui-e2e-tests'

--- a/Makefile
+++ b/Makefile
@@ -37,23 +37,14 @@ $(UI_TEST_DEPS): ui-tests/package-lock.json ui-tests/package.json
 ui-unit-tests: $(UI_TEST_DEPS)
 	npm --prefix ui-tests run ui-unit-test
 
-ui-e2e-tests-run: $(UI_TEST_DEPS)
+ui-e2e-tests: $(UI_TEST_DEPS)
 	npm --prefix ui-tests run ui-e2e-test
-
-ui-e2e-tests:
-	dist/run-isolated-tests.sh -- make ui-e2e-tests-run
 
 ui-tests: ui-unit-tests ui-e2e-tests
 
-integration-tests-run:
+integration-tests:
 	# go test	-v -count=1 -timeout=10s -tags='integration_tests' ./...
 	go test	-count=1 -timeout=10s -tags='integration_tests' ./...
-
-integration-tests:
-	dist/run-isolated-tests.sh -- make integration-tests-run
-
-smoke-tests:
-	dist/run-isolated-tests.sh -- true
 
 test:
 	dist/run-isolated-tests.sh
@@ -75,4 +66,4 @@ clean:
 	rm -rf ui-tests/node_modules
 
 
-.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests-run ui-e2e-tests ui-tests integration-tests-run integration-tests smoke-tests install vet technochat lint install_autodeploy
+.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat lint install_autodeploy

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VET_PACKAGES = $(dir $(addprefix $(MODULE_NAME)/,$(VET_FILES)))
 TARGET_BRANCH ?= master
 GO_BUILD_FLAGS ?= -buildvcs=false
 UI_TEST_DEPS = ui-tests/node_modules/.package-lock.json
-TEST_COMMAND ?= make test-suite
+TEST_COMMAND ?=
 
 all: technochat
 
@@ -47,8 +47,6 @@ integration-tests:
 	# go test	-v -count=1 -timeout=10s -tags='integration_tests' ./...
 	go test	-count=1 -timeout=10s -tags='integration_tests' ./...
 
-test-suite: go-tests integration-tests ui-tests
-
 test:
 	dist/run-isolated-tests.sh -- $(TEST_COMMAND)
 
@@ -69,4 +67,4 @@ clean:
 	rm -rf ui-tests/node_modules
 
 
-.PHONY: all clean test test-suite go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat lint install_autodeploy
+.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat lint install_autodeploy

--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,23 @@ $(UI_TEST_DEPS): ui-tests/package-lock.json ui-tests/package.json
 ui-unit-tests: $(UI_TEST_DEPS)
 	npm --prefix ui-tests run ui-unit-test
 
-ui-e2e-tests: $(UI_TEST_DEPS)
+ui-e2e-tests-run: $(UI_TEST_DEPS)
 	npm --prefix ui-tests run ui-e2e-test
+
+ui-e2e-tests:
+	dist/run-isolated-tests.sh -- make ui-e2e-tests-run
 
 ui-tests: ui-unit-tests ui-e2e-tests
 
-integration-tests:
+integration-tests-run:
 	# go test	-v -count=1 -timeout=10s -tags='integration_tests' ./...
 	go test	-count=1 -timeout=10s -tags='integration_tests' ./...
+
+integration-tests:
+	dist/run-isolated-tests.sh -- make integration-tests-run
+
+smoke-tests:
+	dist/run-isolated-tests.sh -- true
 
 test:
 	dist/run-isolated-tests.sh
@@ -66,4 +75,4 @@ clean:
 	rm -rf ui-tests/node_modules
 
 
-.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat lint install_autodeploy
+.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests-run ui-e2e-tests ui-tests integration-tests-run integration-tests smoke-tests install vet technochat lint install_autodeploy

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ VET_PACKAGES = $(dir $(addprefix $(MODULE_NAME)/,$(VET_FILES)))
 TARGET_BRANCH ?= master
 GO_BUILD_FLAGS ?= -buildvcs=false
 UI_TEST_DEPS = ui-tests/node_modules/.package-lock.json
+TEST_COMMAND ?= make test-suite
 
 all: technochat
 
@@ -46,7 +47,10 @@ integration-tests:
 	# go test	-v -count=1 -timeout=10s -tags='integration_tests' ./...
 	go test	-count=1 -timeout=10s -tags='integration_tests' ./...
 
-test: go-tests integration-tests ui-tests
+test-suite: go-tests integration-tests ui-tests
+
+test:
+	dist/run-isolated-tests.sh -- $(TEST_COMMAND)
 
 install_autodeploy:
 	mkdir -p /opt/technochat
@@ -65,4 +69,4 @@ clean:
 	rm -rf ui-tests/node_modules
 
 
-.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat lint install_autodeploy
+.PHONY: all clean test test-suite go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat lint install_autodeploy

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ VET_PACKAGES = $(dir $(addprefix $(MODULE_NAME)/,$(VET_FILES)))
 TARGET_BRANCH ?= master
 GO_BUILD_FLAGS ?= -buildvcs=false
 UI_TEST_DEPS = ui-tests/node_modules/.package-lock.json
-TEST_COMMAND ?=
 
 all: technochat
 
@@ -48,7 +47,7 @@ integration-tests:
 	go test	-count=1 -timeout=10s -tags='integration_tests' ./...
 
 test:
-	dist/run-isolated-tests.sh -- $(TEST_COMMAND)
+	dist/run-isolated-tests.sh
 
 install_autodeploy:
 	mkdir -p /opt/technochat

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,8 @@ DOCKER_COMPOSE_FILES=(-f dist/docker-compose.yml -f dist/docker-compose-prod.yml
 REQUIRE_LETSENCRYPT=True
 GENERATE_SELF_SIGNED=False
 LETSENCRYPT_DOMAIN="technochat.org"
+DOWN_ONLY=False
+MODE=prod
 
 ARGS=("$@")
 
@@ -12,6 +14,8 @@ print_help() {
     echo "$0 builds required docker images and restarts the running containers"
     echo -e "\tdefault:\trun in production mode"
     echo -e "\t--dev:\trun in developer mode"
+    echo -e "\t--tests:\trun isolated local test environment"
+    echo -e "\t--down:\tstop and remove selected environment"
     echo -e "\t--rc:\trun in RC mode with Let's Encrypt certificate for rc.technochat.org"
     echo -e "\t--help:\tprints this text and exits"
 }
@@ -26,19 +30,41 @@ while [ "$1" != "" ]; do
             DOCKER_COMPOSE_FILES=(-f dist/docker-compose.yml -f dist/docker-compose-dev.yml)
             REQUIRE_LETSENCRYPT=False
             GENERATE_SELF_SIGNED=True
+            MODE=dev
+            ;;
+        "--tests")
+            DOCKER_COMPOSE_FILES=(-f dist/docker-compose.yml -f dist/docker-compose-tests.yml)
+            REQUIRE_LETSENCRYPT=False
+            GENERATE_SELF_SIGNED=True
+            MODE=tests
+            ;;
+        "--down")
+            DOWN_ONLY=True
             ;;
         "--rc")
             DOCKER_COMPOSE_FILES=(-f dist/docker-compose.yml -f dist/docker-compose-rc.yml)
             LETSENCRYPT_DOMAIN="rc.technochat.org"
+            MODE=rc
             ;;
         "--help") print_help; exit 0;;
     esac
     shift
 done
 
+if [ "$DOWN_ONLY" = True ]; then
+    if [ "$MODE" != tests ]; then
+        echo "error: --down is only supported together with --tests"
+        exit 1
+    fi
+
+    compose down -v --remove-orphans || exit
+    echo "done"
+    exit 0
+fi
+
 # generating selfsigned ssl certificates
 if [ "$GENERATE_SELF_SIGNED" = True ] && { [ ! -f certs/server.key ] || [ ! -f certs/server.crt ]; }; then
-    mkdir certs
+    mkdir -p certs
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -subj "/C=US" \
         -keyout certs/server.key -out certs/server.crt || exit
 fi

--- a/dist/docker-compose-tests.yml
+++ b/dist/docker-compose-tests.yml
@@ -1,0 +1,26 @@
+services:
+    nginx:
+        build:
+            args:
+                DEV: "True"
+        secrets:
+            - server.key
+            - server.crt
+        volumes:
+            - ../static:/static
+
+secrets:
+    server.key:
+        file: ../certs/server.key
+    server.crt:
+        file: ../certs/server.crt
+    nginx.conf:
+        file: nginx.conf
+    nginx.http.conf:
+        file: nginx_http_dev.conf
+    nginx.tls.conf:
+        file: nginx_tls_dev.conf
+    nginx.static-cache.conf:
+        file: nginx_static_cache_dev.conf
+    nginx.pwa-cache.conf:
+        file: nginx_pwa_cache_dev.conf

--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -40,8 +40,8 @@ services:
         depends_on:
             - technochat
         ports:
-            - 80:80
-            - 443:443
+            - "${TECHNOCHAT_HTTP_PORT:-80}:80"
+            - "${TECHNOCHAT_HTTPS_PORT:-443}:443"
 
 volumes:
     redis_data:

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -39,7 +39,7 @@ http {
 
         include /etc/nginx/technochat_tls.conf;
 
-        proxy_set_header    Host      $host;
+        proxy_set_header    Host      $http_host;
         proxy_set_header    X-Real-IP $remote_addr;
 
         location = / {

--- a/dist/run-isolated-tests.sh
+++ b/dist/run-isolated-tests.sh
@@ -6,10 +6,6 @@ if [ "${1:-}" = "--" ]; then
     shift
 fi
 
-if [ "$#" = 0 ]; then
-    set -- make test-suite
-fi
-
 port_is_free() {
     local port="$1"
 
@@ -67,8 +63,28 @@ export UI_TEST_BASE_URL="https://127.0.0.1:${TECHNOCHAT_HTTPS_PORT}"
 export TECHNOCHAT_TEST_API_URL="$UI_TEST_BASE_URL"
 
 set +e
-"$@"
-status=$?
+if [ "$#" = 0 ]; then
+    make go-tests
+    status=$?
+
+    if [ "$status" = 0 ]; then
+        make integration-tests
+        status=$?
+    fi
+
+    if [ "$status" = 0 ]; then
+        make ui-unit-tests
+        status=$?
+    fi
+
+    if [ "$status" = 0 ]; then
+        make ui-e2e-tests
+        status=$?
+    fi
+else
+    "$@"
+    status=$?
+fi
 set -e
 
 if [ "$status" != 0 ]; then

--- a/dist/run-isolated-tests.sh
+++ b/dist/run-isolated-tests.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+
+if [ "$#" = 0 ]; then
+    set -- make test-suite
+fi
+
+port_is_free() {
+    local port="$1"
+
+    ! lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+find_free_port() {
+    local start="$1"
+    local port="$start"
+
+    while ! port_is_free "$port"; do
+        port=$((port + 1))
+    done
+
+    echo "$port"
+}
+
+safe_user="$(printf '%s' "${USER:-user}" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"
+safe_name="$(basename "$(pwd)" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"
+port_offset=$(( $$ % 1000 ))
+if [ -z "$safe_name" ]; then
+    safe_name="worktree"
+fi
+if [ -z "$safe_user" ]; then
+    safe_user="user"
+fi
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-technochat_tests_${safe_user}_${safe_name}_$$}"
+export TECHNOCHAT_HTTP_PORT="${TECHNOCHAT_HTTP_PORT:-$(find_free_port $((18080 + port_offset)))}"
+export TECHNOCHAT_HTTPS_PORT="${TECHNOCHAT_HTTPS_PORT:-$(find_free_port $((18443 + port_offset)))}"
+
+cleanup() {
+    ./deploy.sh --tests --down >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+./deploy.sh --tests
+
+for i in {1..20}; do
+    if curl -kfs "https://127.0.0.1:${TECHNOCHAT_HTTPS_PORT}/" >/dev/null; then
+        break
+    fi
+
+    if [ "$i" = 20 ]; then
+        echo "error: isolated HTTPS server did not start on port ${TECHNOCHAT_HTTPS_PORT}" >&2
+        docker compose -f dist/docker-compose.yml -f dist/docker-compose-tests.yml ps >&2 || true
+        docker compose -f dist/docker-compose.yml -f dist/docker-compose-tests.yml logs --no-color >&2 || true
+        exit 1
+    fi
+
+    sleep 1
+done
+
+export UI_TEST_BASE_URL="https://127.0.0.1:${TECHNOCHAT_HTTPS_PORT}"
+export TECHNOCHAT_TEST_API_URL="$UI_TEST_BASE_URL"
+
+set +e
+"$@"
+status=$?
+set -e
+
+if [ "$status" != 0 ]; then
+    docker compose -f dist/docker-compose.yml -f dist/docker-compose-tests.yml ps >&2 || true
+    docker compose -f dist/docker-compose.yml -f dist/docker-compose-tests.yml logs --no-color >&2 || true
+fi
+
+exit "$status"

--- a/dist/run-isolated-tests.sh
+++ b/dist/run-isolated-tests.sh
@@ -68,7 +68,7 @@ if [ "$#" = 0 ]; then
     status=$?
 
     if [ "$status" = 0 ]; then
-        make integration-tests-run
+        make integration-tests
         status=$?
     fi
 
@@ -78,7 +78,7 @@ if [ "$#" = 0 ]; then
     fi
 
     if [ "$status" = 0 ]; then
-        make ui-e2e-tests-run
+        make ui-e2e-tests
         status=$?
     fi
 else

--- a/dist/run-isolated-tests.sh
+++ b/dist/run-isolated-tests.sh
@@ -68,7 +68,7 @@ if [ "$#" = 0 ]; then
     status=$?
 
     if [ "$status" = 0 ]; then
-        make integration-tests
+        make integration-tests-run
         status=$?
     fi
 
@@ -78,7 +78,7 @@ if [ "$#" = 0 ]; then
     fi
 
     if [ "$status" = 0 ]; then
-        make ui-e2e-tests
+        make ui-e2e-tests-run
         status=$?
     fi
 else

--- a/internal/http/imageadd_test.go
+++ b/internal/http/imageadd_test.go
@@ -18,12 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	testAPIAddr = "https://127.0.0.1"
-)
-
 var (
-	imageAddAPI = testAPIAddr + imageAddPath
+	imageAddAPI = testAPIBaseURL() + imageAddPath
 )
 
 func addImage(img []byte) (string, error) {

--- a/internal/http/imageview_test.go
+++ b/internal/http/imageview_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	imageViewAPI = testAPIAddr + imageViewPath
+	imageViewAPI = testAPIBaseURL() + imageViewPath
 
 	dummyImageBytes = []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7}
 )

--- a/internal/http/integration_test.go
+++ b/internal/http/integration_test.go
@@ -1,0 +1,18 @@
+//go:build integration_tests
+// +build integration_tests
+
+package http
+
+import (
+	"os"
+	"strings"
+)
+
+func testAPIBaseURL() string {
+	baseURL := os.Getenv("TECHNOCHAT_TEST_API_URL")
+	if baseURL == "" {
+		baseURL = "https://127.0.0.1"
+	}
+
+	return strings.TrimRight(baseURL, "/")
+}

--- a/internal/http/messageadd_test.go
+++ b/internal/http/messageadd_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	messageAddAPI = testAPIAddr + messageAddPath
+	messageAddAPI = testAPIBaseURL() + messageAddPath
 
 	dummyText = "this a test text"
 	dummyImgs = "6a938b32-e701-4807-b099-ddfbd19ecd22,46f46909-4871-4a98-b3a7-be605032efe5"

--- a/internal/http/messageview_test.go
+++ b/internal/http/messageview_test.go
@@ -25,18 +25,18 @@ func messageView(id string) (entity.Message, error) {
 		},
 	}
 
-	url := url.URL{
-		Scheme: "https",
-		Host:   "127.0.0.1",
-		Path:   messageViewPath,
+	reqURL, err := url.Parse(testAPIBaseURL())
+	if err != nil {
+		return entity.Message{}, fmt.Errorf("could not parse test API URL: %w", err)
 	}
 
-	query := url.Query()
+	reqURL.Path = messageViewPath
+	query := reqURL.Query()
 	query.Add("id", id)
 
-	url.RawQuery = query.Encode()
+	reqURL.RawQuery = query.Encode()
 
-	httpReq, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	httpReq, err := http.NewRequest(http.MethodGet, reqURL.String(), nil)
 	if err != nil {
 		return entity.Message{}, fmt.Errorf("could not make a request: %w", err)
 	}

--- a/ui-tests/tests/chat-flow.e2e.spec.js
+++ b/ui-tests/tests/chat-flow.e2e.spec.js
@@ -4,7 +4,7 @@ test("@e2e creates a temporary chat and exchanges messages over WebSocket", asyn
   page,
   browser,
 }) => {
-  await page.goto("/html/initchat.html");
+  await page.goto("/html/initchat.html", { waitUntil: "domcontentloaded" });
   await page.locator("button", { hasText: "Create chat" }).click();
 
   const linkInput = page.locator("#to_copy");
@@ -16,8 +16,8 @@ test("@e2e creates a temporary chat and exchanges messages over WebSocket", asyn
   const thirdUserPage = await browser.newPage();
 
   try {
-    await firstUserPage.goto(chatLink);
-    await secondUserPage.goto(chatLink);
+    await firstUserPage.goto(chatLink, { waitUntil: "domcontentloaded" });
+    await secondUserPage.goto(chatLink, { waitUntil: "domcontentloaded" });
 
     await expect(firstUserPage.locator("#chat-messages")).toContainText(
       "has joined"
@@ -36,7 +36,7 @@ test("@e2e creates a temporary chat and exchanges messages over WebSocket", asyn
       "hello from chat e2e"
     );
 
-    await thirdUserPage.goto(chatLink);
+    await thirdUserPage.goto(chatLink, { waitUntil: "domcontentloaded" });
     await expect(thirdUserPage.locator("#app")).toContainText(/poshel nah/i);
   } finally {
     await firstUserPage.close();

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -133,7 +133,8 @@ test.beforeEach(async ({ page }) => {
 async function openJoinChat(page) {
   await routeJoinChatWorktreeStatic(page);
   await page.goto(
-    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
+    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`,
+    { waitUntil: "commit" }
   );
   await page.waitForFunction(() => Boolean(window.__technochatMockSocket));
 }
@@ -141,7 +142,8 @@ async function openJoinChat(page) {
 async function openJoinChatScript(page) {
   await routeJoinChatWorktreeStatic(page);
   await page.goto(
-    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
+    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`,
+    { waitUntil: "commit" }
   );
   await page.waitForFunction(() => typeof window.onfocus === "function");
 }

--- a/ui-tests/tests/message-flow.e2e.spec.js
+++ b/ui-tests/tests/message-flow.e2e.spec.js
@@ -11,7 +11,7 @@ test("@e2e creates, opens, decrypts, and consumes a one-time message", async ({
 }) => {
   const messageText = "secret from playwright\nsecond line";
 
-  await page.goto("/html/messageadd.html");
+  await page.goto("/html/messageadd.html", { waitUntil: "domcontentloaded" });
   await page.locator("#text").fill(messageText);
   await page.locator("#generate_button").click();
 
@@ -21,7 +21,7 @@ test("@e2e creates, opens, decrypts, and consumes a one-time message", async ({
   );
 
   const messageLink = await linkInput.inputValue();
-  await page.goto(messageLink);
+  await page.goto(messageLink, { waitUntil: "domcontentloaded" });
 
   await expect(page.locator("#message")).toContainText("secret from playwright");
   await expect(page.locator("#message")).toContainText("second line");
@@ -37,7 +37,7 @@ test("@e2e creates, opens, decrypts, and consumes a one-time message", async ({
 
   const replyViewPage = await browser.newPage();
   try {
-    await replyViewPage.goto(replyLink);
+    await replyViewPage.goto(replyLink, { waitUntil: "domcontentloaded" });
     await expect(replyViewPage.locator("#message")).toHaveText(
       "reply from message view"
     );
@@ -47,7 +47,7 @@ test("@e2e creates, opens, decrypts, and consumes a one-time message", async ({
 
   const secondViewPage = await browser.newPage();
   try {
-    await secondViewPage.goto(messageLink);
+    await secondViewPage.goto(messageLink, { waitUntil: "domcontentloaded" });
     await expect(secondViewPage.locator("#message")).toHaveText(/not found/i);
   } finally {
     await secondViewPage.close();
@@ -60,7 +60,7 @@ test("@e2e creates, opens, decrypts, and renders message images", async ({
 }) => {
   const messageText = "secret images from playwright";
 
-  await page.goto("/html/messageadd.html");
+  await page.goto("/html/messageadd.html", { waitUntil: "domcontentloaded" });
   await page.locator("#text").fill(messageText);
   await page.setInputFiles("#file-input", [
     {
@@ -90,7 +90,7 @@ test("@e2e creates, opens, decrypts, and renders message images", async ({
   );
 
   const messageLink = await linkInput.inputValue();
-  await page.goto(messageLink);
+  await page.goto(messageLink, { waitUntil: "domcontentloaded" });
 
   await expect(page.locator("#message")).toHaveText(messageText);
   await expect(page.locator("#images img")).toHaveCount(3);
@@ -102,7 +102,7 @@ test("@e2e creates, opens, decrypts, and renders message images", async ({
 
   const secondViewPage = await browser.newPage();
   try {
-    await secondViewPage.goto(messageLink);
+    await secondViewPage.goto(messageLink, { waitUntil: "domcontentloaded" });
     await expect(secondViewPage.locator("#message")).toHaveText(/not found/i);
   } finally {
     await secondViewPage.close();


### PR DESCRIPTION
## Что изменилось

- Добавлен isolated test mode для локального и CI-запуска backend-зависимых тестов через отдельный compose project, случайные свободные порты и автоматический cleanup.
- Базовый compose теперь сохраняет дефолтные порты 80/443, но позволяет переопределять их через env для тестового окружения.
- Integration tests теперь читают base URL из TECHNOCHAT_TEST_API_URL с прежним дефолтом https://127.0.0.1.
- GitHub Actions разбит на отдельные видимые шаги: smoke, Go tests, integration tests, UI unit tests и UI end-to-end tests.

## Зачем

Параллельные локальные сессии больше не должны делить один nginx/backend/redis instance во время integration и UI e2e тестов. Обычный prod/dev flow с фиксированными именами контейнеров сохранён.

## Проверки

- bash -n deploy.sh dist/run-isolated-tests.sh
- docker compose -f dist/docker-compose.yml -f dist/docker-compose-tests.yml config
- go test -run '^$' -tags='integration_tests' ./internal/http
- make go-tests
- make lint
