### PR TITLE
Improve PWA loading experience

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -66,7 +66,7 @@ http {
         }
 
         # Static files
-        location ~ ^/(css|js|images)/ {
+        location ~ ^/(css|js|images|media)/ {
             root      /static;
             autoindex off;
             include /etc/nginx/technochat_static_cache.conf;

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -1,7 +1,5 @@
-@import url('https://fonts.googleapis.com/css?family=Press+Start+2P');
-@import url('https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700&subset=cyrillic');
-
 html {
+  color-scheme: light;
   background: #dddddd;
   height: 100%;
 }
@@ -24,6 +22,7 @@ button {
 }
 
 .wrapper {
+  background-color: #dddddd;
   height: 100vh;
   height: 100dvh;
   padding: max(24px, env(safe-area-inset-top)) 20px max(32px, env(safe-area-inset-bottom));

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -19,12 +19,60 @@
     src: url('/css/fonts/ubuntu-mono-v19-bold.ttf') format('truetype');
 }
 
+html {
+    color-scheme: light;
+    background-color: #dddddd;
+}
+
+[v-cloak] {
+    display: none !important;
+}
+
 body {
     font-family: 'Ubuntu Mono', monospace;
     background-color: #dddddd;
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+}
+
+.network-loader {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    width: 100%;
+    height: 3px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.18s ease;
+}
+
+.network-loader--visible {
+    opacity: 1;
+}
+
+.network-loader__bar {
+    display: block;
+    width: 42%;
+    height: 100%;
+    background: #111111;
+    box-shadow: 0 0 14px rgba(17, 17, 17, 0.35);
+    animation: network-loader-slide 1s ease-in-out infinite;
+}
+
+@keyframes network-loader-slide {
+    0% {
+        transform: translateX(-110%);
+    }
+
+    55% {
+        transform: translateX(100vw);
+    }
+
+    100% {
+        transform: translateX(100vw);
+    }
 }
 
 input,

--- a/static/html/initchat.html
+++ b/static/html/initchat.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <title>Technochat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
-    <meta name="theme-color" content="#101010">
+    <meta name="color-scheme" content="light">
+    <meta name="theme-color" content="#dddddd">
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="apple-touch-icon" sizes="167x167" href="/images/apple-touch-icon-167x167.png">
@@ -14,6 +15,7 @@
     <link rel="stylesheet" href="/css/adaptive.css">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <script src="/js/lib/jquery-3.6.0.min.js"></script>
+    <script src="/js/network-loader.js"></script>
     <script src="/js/pwa.js"></script>
     <script type="module" src="/js/chat/init.js"></script>
 </head>
@@ -43,7 +45,7 @@
         <button class="button" id="copy_button">
             Copy link
         </button>
-        <a href="#" class="button" id="join_button" target="_blank" rel="noopener">Join</a>
+        <a href="#" class="button" id="join_button">Join</a>
     </div>
 </div>
 </body>

--- a/static/html/joinchat.html
+++ b/static/html/joinchat.html
@@ -4,14 +4,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, viewport-fit=cover">
     <title>TechnoChat</title>
+    <meta name="color-scheme" content="light">
     <meta name="theme-color" content="#dddddd">
+    <style>
+        html,
+        body {
+            background: #dddddd;
+            color-scheme: light;
+        }
+    </style>
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="apple-touch-icon" sizes="167x167" href="/images/apple-touch-icon-167x167.png">
     <link rel="apple-touch-icon" sizes="152x152" href="/images/apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" sizes="120x120" href="/images/apple-touch-icon-120x120.png">
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="/css/lib/material_icons.css">
     <link rel="stylesheet" href="/css/lib/emojione.min.css">
     <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/chat.css">
@@ -25,7 +33,7 @@
                 <h1><a href="/">Technochat</a></h1>
             </div>
         </div>
-        <div class="main" id="app">
+        <div class="main" id="app" v-cloak>
             <div v-if="okconnected" class="chat_shell">
                 <div class="presence_bar">
                     <button
@@ -129,6 +137,7 @@
     <script src="/js/lib/vue.min.js"></script>
     <script src="/js/lib/emojione.min.js"></script>
     <script src="/js/lib/jquery-3.6.0.min.js"></script>
+    <script src="/js/network-loader.js"></script>
     <script src="/js/lib/md5.js"></script>
     <script src="/js/lib/materialize.min.js"></script>
     <script src="/js/lib/PageTitleNotification.js"></script>

--- a/static/html/messageadd.html
+++ b/static/html/messageadd.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <title>Technochat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
-    <meta name="theme-color" content="#101010">
+    <meta name="color-scheme" content="light">
+    <meta name="theme-color" content="#dddddd">
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="apple-touch-icon" sizes="167x167" href="/images/apple-touch-icon-167x167.png">
@@ -14,6 +15,7 @@
     <link rel="stylesheet" href="/css/adaptive.css">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <script src="/js/lib/jquery-3.6.0.min.js"></script>
+    <script src="/js/network-loader.js"></script>
     <script src="/js/lib/heic2any.min.js"></script>
     <script src="/js/pwa.js"></script>
     <script type="module" src="/js/message/add.js"></script>

--- a/static/html/messageview.html
+++ b/static/html/messageview.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <title>Technochat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
-    <meta name="theme-color" content="#101010">
+    <meta name="color-scheme" content="light">
+    <meta name="theme-color" content="#dddddd">
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
     <link rel="apple-touch-icon" sizes="167x167" href="/images/apple-touch-icon-167x167.png">
@@ -14,6 +15,7 @@
     <link rel="stylesheet" href="/css/adaptive.css">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <script src="/js/lib/jquery-3.6.0.min.js"></script>
+    <script src="/js/network-loader.js"></script>
     <script src="/js/lib/heic2any.min.js"></script>
     <script src="/js/pwa.js"></script>
     <script type="module" src="/js/message/add.js"></script>

--- a/static/js/chat/init.js
+++ b/static/js/chat/init.js
@@ -4,6 +4,36 @@ import {AESGCM128, ArrayBufferToBase64, Encrypter} from "/js/message/crypto.js";
 let copyButtonView;
 let joinButtonView;
 
+function isStandalonePWA() {
+    return window.matchMedia('(display-mode: standalone)').matches ||
+        window.navigator.standalone === true;
+}
+
+function configureJoinButton(link) {
+    joinButtonView.href = link;
+
+    if (isStandalonePWA()) {
+        joinButtonView.removeAttribute('target');
+        joinButtonView.removeAttribute('rel');
+        return;
+    }
+
+    joinButtonView.target = '_blank';
+    joinButtonView.rel = 'noopener';
+}
+
+function onJoinClick(e) {
+    const joinLink = joinButtonView.getAttribute('href');
+    if (!joinLink || joinLink === '#') {
+        e.preventDefault();
+        return;
+    }
+
+    if (isStandalonePWA() && window.TechnochatNetworkLoader) {
+        window.TechnochatNetworkLoader.start();
+    }
+}
+
 function onSubmit(e) {
     $("#loading").show();
     util.resetCopyButton('copy_button');
@@ -51,7 +81,7 @@ async function onSubmitSuccess(json) {
 
         var link = window.location.origin + '/html/joinchat.html?id=' + id + '#key=' + encodeURIComponent(key);
         $('#result_link').html('<input id="to_copy" value="' + link + '">' + link + '</input>');
-        joinButtonView.href = link;
+        configureJoinButton(link);
         joinButtonView.style.display = "inline-flex";
     } else {
         $("#result_link").html("error: " + json.body);
@@ -85,6 +115,7 @@ function initPage() {
 
     joinButtonView = document.getElementById("join_button");
     joinButtonView.style.display = "none";
+    joinButtonView.addEventListener('click', onJoinClick);
 
     $("form").submit(onSubmit);
 }

--- a/static/js/network-loader.js
+++ b/static/js/network-loader.js
@@ -1,0 +1,217 @@
+(function () {
+    const loaderId = 'network_loader';
+    const visibleClass = 'network-loader--visible';
+    const settlingDelayMs = 120;
+
+    let activeRequests = 0;
+    let hideTimer = null;
+
+    function ensureLoader() {
+        let loader = document.getElementById(loaderId);
+        if (loader) {
+            return loader;
+        }
+
+        if (!document.body) {
+            return null;
+        }
+
+        loader = document.createElement('div');
+        loader.id = loaderId;
+        loader.className = 'network-loader';
+        loader.setAttribute('role', 'status');
+        loader.setAttribute('aria-live', 'polite');
+        loader.setAttribute('aria-label', 'Loading');
+
+        const bar = document.createElement('span');
+        bar.className = 'network-loader__bar';
+        bar.setAttribute('aria-hidden', 'true');
+        loader.appendChild(bar);
+
+        document.body.appendChild(loader);
+        return loader;
+    }
+
+    function showLoader() {
+        if (hideTimer) {
+            window.clearTimeout(hideTimer);
+            hideTimer = null;
+        }
+
+        const loader = ensureLoader();
+        if (loader) {
+            loader.classList.add(visibleClass);
+        }
+    }
+
+    function hideLoader() {
+        if (activeRequests > 0) {
+            return;
+        }
+
+        hideTimer = window.setTimeout(function () {
+            const loader = ensureLoader();
+            if (loader) {
+                loader.classList.remove(visibleClass);
+            }
+        }, settlingDelayMs);
+    }
+
+    function trackStart() {
+        activeRequests += 1;
+        showLoader();
+    }
+
+    function trackEnd() {
+        activeRequests = Math.max(0, activeRequests - 1);
+        hideLoader();
+    }
+
+    function trackPromise(promise) {
+        trackStart();
+        return promise.finally(trackEnd);
+    }
+
+    function patchWebSocket() {
+        if (!window.WebSocket || window.WebSocket.__technochatNetworkLoader) {
+            return;
+        }
+
+        const OriginalWebSocket = window.WebSocket;
+
+        function TrackedWebSocket(url, protocols) {
+            const socket = protocols === undefined
+                ? new OriginalWebSocket(url)
+                : new OriginalWebSocket(url, protocols);
+            let isConnecting = true;
+
+            function finishConnecting() {
+                if (!isConnecting) {
+                    return;
+                }
+
+                isConnecting = false;
+                trackEnd();
+            }
+
+            trackStart();
+            socket.addEventListener('open', finishConnecting);
+            socket.addEventListener('error', finishConnecting);
+            socket.addEventListener('close', finishConnecting);
+
+            return socket;
+        }
+
+        TrackedWebSocket.prototype = OriginalWebSocket.prototype;
+        TrackedWebSocket.CONNECTING = OriginalWebSocket.CONNECTING;
+        TrackedWebSocket.OPEN = OriginalWebSocket.OPEN;
+        TrackedWebSocket.CLOSING = OriginalWebSocket.CLOSING;
+        TrackedWebSocket.CLOSED = OriginalWebSocket.CLOSED;
+        TrackedWebSocket.__technochatNetworkLoader = true;
+        window.WebSocket = TrackedWebSocket;
+    }
+
+    function patchSameWindowNavigation() {
+        if (window.__technochatNavigationLoader) {
+            return;
+        }
+
+        window.__technochatNavigationLoader = true;
+        document.addEventListener('click', function(event) {
+            if (event.defaultPrevented || event.button !== 0 ||
+                event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                return;
+            }
+
+            const link = event.target.closest && event.target.closest('a[href]');
+            if (!link || link.hasAttribute('download')) {
+                return;
+            }
+
+            const href = link.getAttribute('href');
+            if (!href || href === '#') {
+                return;
+            }
+
+            const target = (link.getAttribute('target') || '').toLowerCase();
+            if (target && target !== '_self') {
+                return;
+            }
+
+            const url = new URL(link.href, window.location.href);
+            if (url.origin !== window.location.origin) {
+                return;
+            }
+
+            if (url.pathname === window.location.pathname &&
+                url.search === window.location.search &&
+                url.hash) {
+                return;
+            }
+
+            trackStart();
+        }, true);
+    }
+
+    function patchFetch() {
+        if (!window.fetch || window.fetch.__technochatNetworkLoader) {
+            return;
+        }
+
+        const originalFetch = window.fetch.bind(window);
+        const trackedFetch = function () {
+            return trackPromise(originalFetch.apply(null, arguments));
+        };
+
+        trackedFetch.__technochatNetworkLoader = true;
+        window.fetch = trackedFetch;
+    }
+
+    function patchJQueryAjax() {
+        if (!window.jQuery || !window.jQuery.ajax || window.jQuery.ajax.__technochatNetworkLoader) {
+            return;
+        }
+
+        const originalAjax = window.jQuery.ajax;
+        const trackedAjax = function () {
+            trackStart();
+
+            const request = originalAjax.apply(this, arguments);
+            request.always(trackEnd);
+            return request;
+        };
+
+        trackedAjax.__technochatNetworkLoader = true;
+        window.jQuery.ajax = trackedAjax;
+        window.$.ajax = trackedAjax;
+    }
+
+    function init() {
+        window.TechnochatNetworkLoader = {
+            start: trackStart,
+            end: trackEnd,
+        };
+
+        patchFetch();
+        patchJQueryAjax();
+        patchWebSocket();
+        patchSameWindowNavigation();
+
+        if (document.body) {
+            const loader = ensureLoader();
+            if (loader && activeRequests > 0) {
+                loader.classList.add(visibleClass);
+            }
+            return;
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            const loader = ensureLoader();
+            if (loader && activeRequests > 0) {
+                loader.classList.add(visibleClass);
+            }
+        });
+    }
+
+    init();
+})();

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "/html/messageadd.html",
   "scope": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#101010",
+  "background_color": "#dddddd",
+  "theme_color": "#dddddd",
   "icons": [
     {
       "src": "/images/icon.svg",

--- a/static/sw.js
+++ b/static/sw.js
@@ -3,11 +3,35 @@ const IS_LOCAL_DEV = self.location.hostname === '127.0.0.1' || self.location.hos
 
 const CACHE_URLS = [
   '/html/messageadd.html',
+  '/html/messageview.html',
+  '/html/initchat.html',
+  '/html/joinchat.html',
+  '/manifest.webmanifest',
   '/css/main.css',
   '/css/adaptive.css',
+  '/css/chat.css',
+  '/css/lib/emojione.min.css',
+  '/css/lib/material_icons.css',
+  '/css/fonts/press-start-2p-v16.ttf',
+  '/css/fonts/ubuntu-mono-v19-bold.ttf',
+  '/css/fonts/ubuntu-mono-v19-regular.ttf',
+  '/css/fonts/material-icons-v38.ttf',
+  '/js/network-loader.js',
   '/js/pwa.js',
   '/js/message/add.js',
+  '/js/message/view.js',
+  '/js/message/crypto.js',
+  '/js/chat/init.js',
+  '/js/chat/chat.js',
+  '/js/util.js',
   '/js/lib/jquery-3.6.0.min.js',
+  '/js/lib/vue.min.js',
+  '/js/lib/emojione.min.js',
+  '/js/lib/heic2any.min.js',
+  '/js/lib/md5.js',
+  '/js/lib/materialize.min.js',
+  '/js/lib/PageTitleNotification.js',
+  '/media/icons/close.svg',
   '/images/apple-touch-icon.png',
   '/images/apple-touch-icon-167x167.png',
   '/images/apple-touch-icon-152x152.png',
@@ -15,6 +39,7 @@ const CACHE_URLS = [
   '/images/icon.svg',
   '/images/icon-512x512.png',
   '/images/icon-192x192.png',
+  '/robots.txt',
   '/favicon.ico'
 ];
 
@@ -68,27 +93,43 @@ if (IS_LOCAL_DEV) {
       return;
     }
 
+    function fetchAndCache(request) {
+      return fetch(request).then(function (response) {
+        if (!response || response.status !== 200 || response.type !== 'basic') {
+          return response;
+        }
+
+        const responseToCache = response.clone();
+        caches.open(CACHE_NAME).then(function (cache) {
+          cache.put(request, responseToCache);
+        });
+
+        return response;
+      });
+    }
+
     event.respondWith(
       caches.match(event.request).then(function (cachedResponse) {
         if (cachedResponse) {
           return cachedResponse;
         }
 
-        return fetch(event.request).then(function (response) {
-          if (!response || response.status !== 200 || response.type !== 'basic') {
-            return response;
-          }
-
-          const responseToCache = response.clone();
-          caches.open(CACHE_NAME).then(function (cache) {
-            cache.put(event.request, responseToCache);
+        if (event.request.mode === 'navigate') {
+          return caches.match(url.pathname).then(function (cachedPageResponse) {
+            return cachedPageResponse || fetchAndCache(event.request);
           });
+        }
 
-          return response;
-        });
+        return fetchAndCache(event.request);
       }).catch(function () {
         if (event.request.mode === 'navigate') {
-          return caches.match('/html/messageadd.html').then(function (cachedResponse) {
+          return caches.match(url.pathname).then(function (cachedResponse) {
+            if (cachedResponse) {
+              return cachedResponse;
+            }
+
+            return caches.match('/html/messageadd.html');
+          }).then(function (cachedResponse) {
             return cachedResponse || new Response('Service unavailable', {
               status: 503,
               headers: { 'Content-Type': 'text/plain' }

--- a/ui-tests/tests/chat-init.unit.spec.js
+++ b/ui-tests/tests/chat-init.unit.spec.js
@@ -42,6 +42,8 @@ test("@unit resets the copy button when a new chat link is generated", async ({
   await expect(page.locator("#to_copy")).toHaveValue(
     /\/html\/joinchat\.html\?id=first-chat#key=/
   );
+  await expect(page.locator("#join_button")).toHaveAttribute("target", "_blank");
+  await expect(page.locator("#join_button")).toHaveAttribute("rel", "noopener");
   await page.locator("#copy_button").click();
   await expect(page.locator("#copy_button")).toHaveText("Copied!");
 
@@ -52,4 +54,93 @@ test("@unit resets the copy button when a new chat link is generated", async ({
   );
   await expect(page.locator("#copy_button")).toHaveText("Copy link");
   expect(initRequestBodies.join("\n")).not.toContain("key");
+});
+
+test("@unit shows a global loader while chat init request is pending", async ({
+  page,
+}) => {
+  let finishRequest;
+  const requestDone = new Promise((resolve) => {
+    finishRequest = resolve;
+  });
+
+  await page.route("**/api/v1/chat/init", async (route) => {
+    await requestDone;
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          id: "loader-chat",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/html/initchat.html");
+  await page.locator("button", { hasText: "Create chat" }).click();
+
+  await expect(page.locator("#network_loader")).toHaveClass(
+    /network-loader--visible/
+  );
+
+  finishRequest();
+
+  await expect(page.locator("#to_copy")).toHaveValue(/loader-chat#key=/);
+  await expect(page.locator("#network_loader")).not.toHaveClass(
+    /network-loader--visible/
+  );
+});
+
+test("@unit keeps Join in the same window and starts loader in PWA mode", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    const originalMatchMedia = window.matchMedia.bind(window);
+    window.matchMedia = (query) => {
+      if (query === "(display-mode: standalone)") {
+        return {
+          matches: true,
+          media: query,
+          onchange: null,
+          addListener() {},
+          removeListener() {},
+          addEventListener() {},
+          removeEventListener() {},
+          dispatchEvent() {
+            return false;
+          },
+        };
+      }
+
+      return originalMatchMedia(query);
+    };
+  });
+
+  await page.route("**/api/v1/chat/init", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        code: 200,
+        body: {
+          id: "pwa-chat",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/html/initchat.html");
+  await page.locator("button", { hasText: "Create chat" }).click();
+
+  const joinButton = page.locator("#join_button");
+  await expect(joinButton).not.toHaveAttribute("target");
+  await expect(joinButton).not.toHaveAttribute("rel");
+
+  await joinButton.evaluate((button) => {
+    button.addEventListener("click", (e) => e.preventDefault());
+  });
+  await joinButton.click();
+  await expect(page.locator("#network_loader")).toHaveClass(
+    /network-loader--visible/
+  );
 });

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -216,6 +216,48 @@ test("@unit does not blink the page title when the chat page is visible", async 
   await expect(page.locator(".chat-message_time")).not.toBeEmpty();
 });
 
+test("@unit keeps the page gray behind the white chat canvas", async ({ page }) => {
+  await routeJoinChatWorktreeStatic(page);
+  await page.addInitScript(installJoinChatMocks);
+
+  await page.goto(
+    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
+  );
+  await expect(page.locator("#chat-messages")).toBeVisible();
+
+  await expect(page.locator("html")).toHaveCSS(
+    "background-color",
+    "rgb(221, 221, 221)"
+  );
+  await expect(page.locator(".chat_content")).toHaveCSS(
+    "background-color",
+    "rgba(255, 255, 255, 0.88)"
+  );
+});
+
+test("@unit shows a global loader while chat WebSocket connects", async ({
+  page,
+}) => {
+  await routeJoinChatWorktreeStatic(page);
+  await page.addInitScript(installJoinChatMocks);
+
+  await page.goto(
+    `/html/joinchat.html?id=chat-id#key=${encodeURIComponent(chatKeyBase64)}`
+  );
+
+  await expect(page.locator("#network_loader")).toHaveClass(
+    /network-loader--visible/
+  );
+
+  await page.evaluate(() => {
+    window.__technochatMockSocket.dispatch("open");
+  });
+
+  await expect(page.locator("#network_loader")).not.toHaveClass(
+    /network-loader--visible/
+  );
+});
+
 test("@unit keeps chat input fixed while messages scroll internally", async ({
   page,
 }) => {

--- a/ui-tests/tests/message-add.unit.spec.js
+++ b/ui-tests/tests/message-add.unit.spec.js
@@ -119,6 +119,22 @@ test("@unit resets the copy button when a new message link is generated", async 
   await expect(page.locator("#copy_button")).toHaveText("Copy link");
 });
 
+test("@unit starts the global loader before navigating to chat creation", async ({
+  page,
+}) => {
+  await page.goto("/html/messageadd.html");
+
+  const createChatLink = page.locator("#create_chat");
+  await createChatLink.evaluate((link) => {
+    link.addEventListener("click", (event) => event.preventDefault());
+  });
+
+  await createChatLink.click();
+  await expect(page.locator("#network_loader")).toHaveClass(
+    /network-loader--visible/
+  );
+});
+
 test("@unit renders API validation errors without clearing the original text", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- add a global network loader for API calls, same-window navigation, and chat WebSocket connection startup
- improve PWA static caching so query-string chat URLs can reuse the cached app shell
- keep PWA navigation light-themed and prevent raw Vue chat UI from flashing before mount
- choose Join behavior by display mode: same window for standalone PWA, new tab for regular browser

## Details
The chat join flow was opening a new standalone window and sometimes waiting on a network fetch for `/html/joinchat.html?id=...`, while the service worker only had `/html/joinchat.html` precached. That made the PWA show a dark system canvas before the app shell rendered. Navigation now uses the same PWA window when installed, cached navigation falls back by pathname, and the app shell is explicitly light-themed.

The online users panel could briefly flash before Vue mounted because the raw `v-if` markup was visible. The chat app root now uses `v-cloak` until Vue takes over.

closes #114

## Checks
- `make go-tests`
- `make lint`
- `git diff --check`
- `node --check static/js/network-loader.js && node --check static/js/chat/init.js && node --check static/sw.js`
