### PR TITLE
Persist chat state in Redis

### DIFF
--- a/cmd/technochat/main.go
+++ b/cmd/technochat/main.go
@@ -35,8 +35,8 @@ func main() {
 
 	log.Println("technochat: initialising")
 
-	httpServer.Init()
 	db.Init()
+	httpServer.Init()
 
 	log.Println("technochat: successfully initialised")
 	log.Println("technochat: starting")

--- a/dist/docker-compose-tests.yml
+++ b/dist/docker-compose-tests.yml
@@ -1,4 +1,8 @@
 services:
+    redis:
+        ports:
+            - "${TECHNOCHAT_REDIS_PORT:-6379}:6379"
+
     nginx:
         build:
             args:

--- a/dist/run-isolated-tests.sh
+++ b/dist/run-isolated-tests.sh
@@ -36,6 +36,7 @@ fi
 export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-technochat_tests_${safe_user}_${safe_name}_$$}"
 export TECHNOCHAT_HTTP_PORT="${TECHNOCHAT_HTTP_PORT:-$(find_free_port $((18080 + port_offset)))}"
 export TECHNOCHAT_HTTPS_PORT="${TECHNOCHAT_HTTPS_PORT:-$(find_free_port $((18443 + port_offset)))}"
+export TECHNOCHAT_REDIS_PORT="${TECHNOCHAT_REDIS_PORT:-$(find_free_port $((16379 + port_offset)))}"
 
 cleanup() {
     ./deploy.sh --tests --down >/dev/null 2>&1 || true
@@ -61,6 +62,7 @@ done
 
 export UI_TEST_BASE_URL="https://127.0.0.1:${TECHNOCHAT_HTTPS_PORT}"
 export TECHNOCHAT_TEST_API_URL="$UI_TEST_BASE_URL"
+export TECHNOCHAT_TEST_REDIS_ADDR="127.0.0.1:${TECHNOCHAT_REDIS_PORT}"
 
 set +e
 if [ "$#" = 0 ]; then

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -22,6 +22,7 @@ const (
 	MaxPeopleInChat  = 100
 
 	ChatOfflineTTL        time.Duration = 24 * time.Hour
+	ChatStateRefreshRate  time.Duration = time.Minute
 	PresenceBroadcastRate time.Duration = 30 * time.Second
 	TypingTTL             time.Duration = 3 * time.Second
 	TypingExpireRate      time.Duration = 500 * time.Millisecond
@@ -55,6 +56,7 @@ type Chat struct {
 	broadcastChan    chan *message.WSMessage
 	offlineStateChan chan bool
 	offlineTTL       time.Duration
+	stateRefreshRate time.Duration
 	typingUsers      *typingusers.TypingUsers
 
 	restJoins         int // how many available invitations are left
@@ -87,6 +89,7 @@ type NewChatOpts struct {
 	RestoreRestJoins bool
 	Participants     []Participant
 	OfflineTTL       time.Duration
+	StateRefreshRate time.Duration
 	Store            StateStore
 }
 
@@ -94,6 +97,10 @@ func NewChat(opts NewChatOpts) *Chat {
 	offlineTTL := opts.OfflineTTL
 	if offlineTTL <= 0 {
 		offlineTTL = ChatOfflineTTL
+	}
+	stateRefreshRate := opts.StateRefreshRate
+	if stateRefreshRate <= 0 {
+		stateRefreshRate = ChatStateRefreshRate
 	}
 
 	restJoins := opts.MaxJoins
@@ -118,6 +125,7 @@ func NewChat(opts NewChatOpts) *Chat {
 		broadcastChan:        make(chan *message.WSMessage, broadcastBufferSize),
 		offlineStateChan:     make(chan bool, 1),
 		offlineTTL:           offlineTTL,
+		stateRefreshRate:     stateRefreshRate,
 		typingUsers:          typingusers.New(TypingTTL),
 		restJoins:            restJoins,
 		maxUsers:             opts.MaxJoins,
@@ -172,9 +180,10 @@ func (c *Chat) persistState() error {
 	}
 
 	c.correspsMx.RLock()
-	defer c.correspsMx.RUnlock()
+	state := c.stateLocked()
+	c.correspsMx.RUnlock()
 
-	return c.store.UpdateChat(c.stateLocked())
+	return c.store.UpdateChat(state)
 }
 
 func (c *Chat) RestJoins() int {
@@ -378,6 +387,9 @@ func (c *Chat) handleCommunication() {
 	typingTicker := time.NewTicker(TypingExpireRate)
 	defer typingTicker.Stop()
 
+	stateRefreshTicker := time.NewTicker(c.stateRefreshRate)
+	defer stateRefreshTicker.Stop()
+
 	lastTypingBroadcastAt := time.Now()
 	typingBroadcastPending := false
 
@@ -409,6 +421,13 @@ func (c *Chat) handleCommunication() {
 
 		case <-presenceTicker.C:
 			c.broadcast(c.PresenceMessage())
+
+		case <-stateRefreshTicker.C:
+			if c.Presence().Online > 0 {
+				if err := c.persistState(); err != nil {
+					log.Printf("error: chat: could not refresh persisted state for chat %s: %v", c.ID, err)
+				}
+			}
 
 		case <-typingTicker.C:
 			now := time.Now()
@@ -458,9 +477,6 @@ func (c *Chat) handleIncomingMessage(
 ) bool {
 	if incoming == nil || incoming.msg == nil || incoming.user == nil {
 		return typingBroadcastPending
-	}
-	if err := c.persistState(); err != nil {
-		log.Printf("error: chat: could not refresh persisted state for chat %s: %v", c.ID, err)
 	}
 
 	switch incoming.msg.Type {

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -44,6 +44,7 @@ type Chat struct {
 	store     StateStore
 
 	triggerShutdown     sync.Once
+	start               sync.Once
 	triggerShutdownChan chan struct{}
 	shutdownChan        chan struct{}
 	WG                  sync.WaitGroup
@@ -136,12 +137,16 @@ func NewChat(opts NewChatOpts) *Chat {
 		userDisconnectedChan: make(chan *user.User),
 	}
 
-	c.WG.Add(2)
-
-	go c.handleUsers()
-	go c.handleCommunication()
-
 	return c
+}
+
+func (c *Chat) Start() {
+	c.start.Do(func() {
+		c.WG.Add(2)
+
+		go c.handleUsers()
+		go c.handleCommunication()
+	})
 }
 
 func (c *Chat) stateLocked() entity.Chat {
@@ -545,6 +550,8 @@ func (c *Chat) TriggerShutdown() {
 }
 
 func (c *Chat) Routine() {
+	c.Start()
+
 	<-c.triggerShutdownChan
 
 	log.Printf("info: chat: triggered shutdown for chat [%s]", c.ID)

--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -13,6 +13,7 @@ import (
 	"technochat/internal/chat/message"
 	"technochat/internal/chat/typingusers"
 	"technochat/internal/chat/user"
+	"technochat/pkg/entity"
 )
 
 const (
@@ -39,6 +40,7 @@ var Upgrader = websocket.Upgrader{
 type Chat struct {
 	ID        string
 	ChatNames ChatNames
+	store     StateStore
 
 	triggerShutdown     sync.Once
 	triggerShutdownChan chan struct{}
@@ -74,10 +76,18 @@ type Participant struct {
 	ReconnectToken string
 }
 
+type StateStore interface {
+	UpdateChat(chat entity.Chat) error
+}
+
 type NewChatOpts struct {
-	ID         string
-	MaxJoins   int
-	OfflineTTL time.Duration
+	ID               string
+	MaxJoins         int
+	RestJoins        int
+	RestoreRestJoins bool
+	Participants     []Participant
+	OfflineTTL       time.Duration
+	Store            StateStore
 }
 
 func NewChat(opts NewChatOpts) *Chat {
@@ -86,18 +96,32 @@ func NewChat(opts NewChatOpts) *Chat {
 		offlineTTL = ChatOfflineTTL
 	}
 
+	restJoins := opts.MaxJoins
+	if opts.RestoreRestJoins {
+		restJoins = opts.RestJoins
+	}
+
+	participants := make(map[string]*Participant, len(opts.Participants))
+	chatNames := NewChatNames()
+	for _, participant := range opts.Participants {
+		participant := participant
+		participants[participant.ReconnectToken] = &participant
+		chatNames.usedNames[participant.ID] = true
+	}
+
 	c := &Chat{
 		ID:                   opts.ID,
-		participants:         make(map[string]*Participant),
+		store:                opts.Store,
+		participants:         participants,
 		corresps:             make(map[int]*user.User),
 		incomingChan:         make(chan *incomingMessage, incomingBufferSize),
 		broadcastChan:        make(chan *message.WSMessage, broadcastBufferSize),
 		offlineStateChan:     make(chan bool, 1),
 		offlineTTL:           offlineTTL,
 		typingUsers:          typingusers.New(TypingTTL),
-		restJoins:            opts.MaxJoins,
+		restJoins:            restJoins,
 		maxUsers:             opts.MaxJoins,
-		ChatNames:            NewChatNames(),
+		ChatNames:            chatNames,
 		triggerShutdownChan:  make(chan struct{}),
 		shutdownChan:         make(chan struct{}),
 		userConnectedChan:    make(chan *user.User),
@@ -110,6 +134,47 @@ func NewChat(opts NewChatOpts) *Chat {
 	go c.handleCommunication()
 
 	return c
+}
+
+func (c *Chat) stateLocked() entity.Chat {
+	participants := make([]entity.ChatParticipant, 0, len(c.participants))
+	for _, participant := range c.participants {
+		participants = append(participants, entity.ChatParticipant{
+			ID:             participant.ID,
+			Name:           participant.Name,
+			ReconnectToken: participant.ReconnectToken,
+		})
+	}
+
+	sort.Slice(participants, func(i, j int) bool {
+		return participants[i].ID < participants[j].ID
+	})
+
+	return entity.Chat{
+		ID:           c.ID,
+		MaxUsers:     c.maxUsers,
+		RestJoins:    c.restJoins,
+		Participants: participants,
+		TTL:          int(c.offlineTTL.Seconds()),
+	}
+}
+
+func (c *Chat) State() entity.Chat {
+	c.correspsMx.RLock()
+	defer c.correspsMx.RUnlock()
+
+	return c.stateLocked()
+}
+
+func (c *Chat) persistState() error {
+	if c.store == nil {
+		return nil
+	}
+
+	c.correspsMx.RLock()
+	defer c.correspsMx.RUnlock()
+
+	return c.store.UpdateChat(c.stateLocked())
 }
 
 func (c *Chat) RestJoins() int {
@@ -393,6 +458,9 @@ func (c *Chat) handleIncomingMessage(
 ) bool {
 	if incoming == nil || incoming.msg == nil || incoming.user == nil {
 		return typingBroadcastPending
+	}
+	if err := c.persistState(); err != nil {
+		log.Printf("error: chat: could not refresh persisted state for chat %s: %v", c.ID, err)
 	}
 
 	switch incoming.msg.Type {

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -1,10 +1,12 @@
 package chat
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 
 	"technochat/internal/chat/message"
 	"technochat/internal/chat/user"
+	"technochat/pkg/entity"
 )
 
 type testPresence struct {
@@ -29,6 +32,36 @@ type testTypingUser struct {
 type testConnInit struct {
 	Name           string
 	ReconnectToken string
+}
+
+type testChatStateStore struct {
+	mx     sync.Mutex
+	err    error
+	states []entity.Chat
+}
+
+func (s *testChatStateStore) UpdateChat(chat entity.Chat) error {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if s.err != nil {
+		return s.err
+	}
+
+	s.states = append(s.states, chat)
+
+	return nil
+}
+
+func (s *testChatStateStore) lastState() (entity.Chat, bool) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	if len(s.states) == 0 {
+		return entity.Chat{}, false
+	}
+
+	return s.states[len(s.states)-1], true
 }
 
 func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
@@ -56,6 +89,89 @@ func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
 	}
 	if len(presence.Users) != 0 {
 		t.Fatalf("expected empty users list, got %d users", len(presence.Users))
+	}
+}
+
+func TestAddUserPersistsChatState(t *testing.T) {
+	store := &testChatStateStore{}
+	c := NewChat(NewChatOpts{
+		ID:       "state-persist-test",
+		MaxJoins: 2,
+		Store:    store,
+	})
+
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChat(c, done)
+
+	client := dialTestChat(t, server)
+	defer closeTestClient(t, client)
+	readPresenceEvent(t, client, 1)
+
+	state, ok := store.lastState()
+	if !ok {
+		t.Fatalf("expected chat state to be persisted")
+	}
+	if state.ID != c.ID {
+		t.Fatalf("expected chat ID %q, got %q", c.ID, state.ID)
+	}
+	if state.MaxUsers != 2 {
+		t.Fatalf("expected max users 2, got %d", state.MaxUsers)
+	}
+	if state.RestJoins != 1 {
+		t.Fatalf("expected 1 rest join, got %d", state.RestJoins)
+	}
+	if len(state.Participants) != 1 {
+		t.Fatalf("expected 1 persisted participant, got %d", len(state.Participants))
+	}
+	if state.Participants[0].ReconnectToken == "" {
+		t.Fatalf("expected reconnect token to be persisted")
+	}
+	if state.TTL != int(ChatOfflineTTL.Seconds()) {
+		t.Fatalf("expected TTL %d, got %d", int(ChatOfflineTTL.Seconds()), state.TTL)
+	}
+}
+
+func TestAddUserRollsBackJoinWhenStateStoreFails(t *testing.T) {
+	storeErr := errors.New("store unavailable")
+	store := &testChatStateStore{err: storeErr}
+	c := NewChat(NewChatOpts{
+		ID:       "state-persist-fail-test",
+		MaxJoins: 2,
+		Store:    store,
+	})
+
+	addErr := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := Upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("could not upgrade websocket: %v", err)
+			return
+		}
+		defer ws.Close()
+
+		_, err = c.AddUser(ws)
+		addErr <- err
+	}))
+	defer server.Close()
+
+	client := dialTestChat(t, server)
+	defer closeTestClient(t, client)
+
+	select {
+	case err := <-addErr:
+		if err == nil {
+			t.Fatalf("expected add user to fail")
+		}
+		if !strings.Contains(err.Error(), storeErr.Error()) {
+			t.Fatalf("expected store error %q, got %v", storeErr, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for add user")
+	}
+
+	if restJoins := c.RestJoins(); restJoins != 2 {
+		t.Fatalf("expected rest joins to be rolled back to 2, got %d", restJoins)
 	}
 }
 
@@ -118,6 +234,40 @@ func TestReconnectDoesNotConsumeQuotaAndRestoresUser(t *testing.T) {
 	}
 
 	closeTestClient(t, firstClient)
+}
+
+func TestRestoredParticipantCanReconnect(t *testing.T) {
+	c := NewChat(NewChatOpts{
+		ID:               "restored-reconnect-test",
+		MaxJoins:         1,
+		RestJoins:        0,
+		RestoreRestJoins: true,
+		Participants: []Participant{
+			{
+				ID:             7,
+				Name:           "restored user",
+				ReconnectToken: "restored-token",
+			},
+		},
+	})
+
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChat(c, done)
+
+	client := dialTestChatPath(t, server, "/reconnect?reconnect_token=restored-token")
+	defer closeTestClient(t, client)
+
+	init := readConnInitEvent(t, client)
+	if init.Name != "restored user" {
+		t.Fatalf("expected restored user name, got %q", init.Name)
+	}
+	if init.ReconnectToken != "restored-token" {
+		t.Fatalf("expected restored reconnect token, got %q", init.ReconnectToken)
+	}
+	if c.RestJoins() != 0 {
+		t.Fatalf("expected restored reconnect to keep join quota at 0, got %d", c.RestJoins())
+	}
 }
 
 func TestDisconnectKeepsChatAliveUntilOfflineTTL(t *testing.T) {

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -64,6 +64,13 @@ func (s *testChatStateStore) lastState() (entity.Chat, bool) {
 	return s.states[len(s.states)-1], true
 }
 
+func (s *testChatStateStore) stateCount() int {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	return len(s.states)
+}
+
 func TestPresenceReportsConfiguredMaxUsers(t *testing.T) {
 	c := NewChat(NewChatOpts{
 		ID:       "presence-test",
@@ -267,6 +274,82 @@ func TestRestoredParticipantCanReconnect(t *testing.T) {
 	}
 	if c.RestJoins() != 0 {
 		t.Fatalf("expected restored reconnect to keep join quota at 0, got %d", c.RestJoins())
+	}
+}
+
+func TestReconnectRefreshesPersistedChatState(t *testing.T) {
+	store := &testChatStateStore{}
+	c := NewChat(NewChatOpts{
+		ID:               "reconnect-refresh-state-test",
+		MaxJoins:         1,
+		RestJoins:        0,
+		RestoreRestJoins: true,
+		Participants: []Participant{
+			{
+				ID:             7,
+				Name:           "restored user",
+				ReconnectToken: "restored-token",
+			},
+		},
+		Store: store,
+	})
+
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChat(c, done)
+
+	client := dialTestChatPath(t, server, "/reconnect?reconnect_token=restored-token")
+	defer closeTestClient(t, client)
+	readConnInitEvent(t, client)
+
+	state, ok := store.lastState()
+	if !ok {
+		t.Fatalf("expected reconnect to refresh persisted chat state")
+	}
+	if state.TTL != int(ChatOfflineTTL.Seconds()) {
+		t.Fatalf("expected TTL %d, got %d", int(ChatOfflineTTL.Seconds()), state.TTL)
+	}
+	if len(state.Participants) != 1 || state.Participants[0].ReconnectToken != "restored-token" {
+		t.Fatalf("expected restored participant to stay persisted, got %#v", state.Participants)
+	}
+}
+
+func TestIncomingMessageRefreshesPersistedChatState(t *testing.T) {
+	store := &testChatStateStore{}
+	c := NewChat(NewChatOpts{
+		ID:       "message-refresh-state-test",
+		MaxJoins: 1,
+		Store:    store,
+	})
+
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChat(c, done)
+
+	client := dialTestChat(t, server)
+	defer closeTestClient(t, client)
+	readConnInitEvent(t, client)
+
+	initialStateCount := store.stateCount()
+	if initialStateCount == 0 {
+		t.Fatalf("expected join to persist initial chat state")
+	}
+
+	if err := client.WriteJSON(message.WSMessage{
+		Type: message.WSMsgTypeMessage,
+		Data: "hello",
+	}); err != nil {
+		t.Fatalf("could not write chat message: %v", err)
+	}
+
+	waitForPersistedStates(t, store, initialStateCount+1)
+
+	state, ok := store.lastState()
+	if !ok {
+		t.Fatalf("expected message activity to refresh persisted chat state")
+	}
+	if state.TTL != int(ChatOfflineTTL.Seconds()) {
+		t.Fatalf("expected TTL %d, got %d", int(ChatOfflineTTL.Seconds()), state.TTL)
 	}
 }
 
@@ -561,6 +644,21 @@ func waitForOnlineUsers(t *testing.T, c *Chat, expectedOnline int) {
 	}
 
 	t.Fatalf("timed out waiting for %d online users, got %d", expectedOnline, c.Presence().Online)
+}
+
+func waitForPersistedStates(t *testing.T, store *testChatStateStore, expectedStates int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if store.stateCount() >= expectedStates {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %d persisted states, got %d", expectedStates, store.stateCount())
 }
 
 func dialTestChat(t *testing.T, server *httptest.Server) *websocket.Conn {

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -155,7 +155,11 @@ func TestAddUserRollsBackJoinWhenStateStoreFails(t *testing.T) {
 			t.Errorf("could not upgrade websocket: %v", err)
 			return
 		}
-		defer ws.Close()
+		defer func() {
+			if err := ws.Close(); err != nil {
+				t.Errorf("could not close websocket: %v", err)
+			}
+		}()
 
 		_, err = c.AddUser(ws)
 		addErr <- err

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -318,12 +318,13 @@ func TestReconnectRefreshesPersistedChatState(t *testing.T) {
 	}
 }
 
-func TestIncomingMessageRefreshesPersistedChatState(t *testing.T) {
+func TestOpenWebSocketPeriodicallyRefreshesPersistedChatState(t *testing.T) {
 	store := &testChatStateStore{}
 	c := NewChat(NewChatOpts{
-		ID:       "message-refresh-state-test",
-		MaxJoins: 1,
-		Store:    store,
+		ID:               "online-refresh-state-test",
+		MaxJoins:         1,
+		StateRefreshRate: 50 * time.Millisecond,
+		Store:            store,
 	})
 
 	server, done := serveTestChat(t, c)
@@ -339,21 +340,45 @@ func TestIncomingMessageRefreshesPersistedChatState(t *testing.T) {
 		t.Fatalf("expected join to persist initial chat state")
 	}
 
-	if err := client.WriteJSON(message.WSMessage{
-		Type: message.WSMsgTypeMessage,
-		Data: "hello",
-	}); err != nil {
-		t.Fatalf("could not write chat message: %v", err)
-	}
-
 	waitForPersistedStates(t, store, initialStateCount+1)
 
 	state, ok := store.lastState()
 	if !ok {
-		t.Fatalf("expected message activity to refresh persisted chat state")
+		t.Fatalf("expected online chat to refresh persisted chat state")
 	}
 	if state.TTL != int(ChatOfflineTTL.Seconds()) {
 		t.Fatalf("expected TTL %d, got %d", int(ChatOfflineTTL.Seconds()), state.TTL)
+	}
+}
+
+func TestOfflineChatDoesNotPeriodicallyRefreshPersistedState(t *testing.T) {
+	store := &testChatStateStore{}
+	c := NewChat(NewChatOpts{
+		ID:               "offline-refresh-state-test",
+		MaxJoins:         1,
+		OfflineTTL:       time.Second,
+		StateRefreshRate: 50 * time.Millisecond,
+		Store:            store,
+	})
+
+	server, done := serveTestChat(t, c)
+	defer server.Close()
+	defer stopTestChatIfRunning(c, done)
+
+	client := dialTestChat(t, server)
+	readConnInitEvent(t, client)
+
+	initialStateCount := store.stateCount()
+	if initialStateCount == 0 {
+		t.Fatalf("expected join to persist initial chat state")
+	}
+
+	closeTestClient(t, client)
+	waitForOnlineUsers(t, c, 0)
+	time.Sleep(150 * time.Millisecond)
+
+	if stateCount := store.stateCount(); stateCount != initialStateCount {
+		t.Fatalf("expected offline chat not to refresh persisted state, got %d states", stateCount)
 	}
 }
 

--- a/internal/chat/chatslist.go
+++ b/internal/chat/chatslist.go
@@ -24,6 +24,20 @@ func AddChat(c *Chat) {
 	chatsList.mx.Unlock()
 }
 
+func AddChatIfAbsent(c *Chat) (*Chat, bool) {
+	chatsList.mx.Lock()
+	defer chatsList.mx.Unlock()
+
+	existingChat, ok := chatsList.chats[c.ID]
+	if ok {
+		return existingChat, false
+	}
+
+	chatsList.chats[c.ID] = c
+
+	return c, true
+}
+
 func GetChat(id string) *Chat {
 	chatsList.mx.Lock()
 	defer chatsList.mx.Unlock()

--- a/internal/chat/chatslist.go
+++ b/internal/chat/chatslist.go
@@ -9,9 +9,16 @@ import (
 )
 
 type Registry struct {
-	chats map[string]*Chat
-	store RestoreStore
-	mx    sync.Mutex
+	chats     map[string]*Chat
+	restoring map[string]*restoreCall
+	store     RestoreStore
+	mx        sync.Mutex
+}
+
+type restoreCall struct {
+	done chan struct{}
+	chat *Chat
+	err  error
 }
 
 type RestoreStore interface {
@@ -22,8 +29,9 @@ type RestoreStore interface {
 
 func NewRegistry(store RestoreStore) *Registry {
 	return &Registry{
-		chats: make(map[string]*Chat),
-		store: store,
+		chats:     make(map[string]*Chat),
+		restoring: make(map[string]*restoreCall),
+		store:     store,
 	}
 }
 
@@ -51,12 +59,35 @@ func (r *Registry) GetChat(id string) (*Chat, error) {
 	r.mx.Lock()
 	c := r.chats[id]
 	store := r.store
-	r.mx.Unlock()
-
 	if c != nil || store == nil {
+		r.mx.Unlock()
+
 		return c, nil
 	}
 
+	if call, ok := r.restoring[id]; ok {
+		r.mx.Unlock()
+		<-call.done
+
+		return call.chat, call.err
+	}
+
+	call := &restoreCall{done: make(chan struct{})}
+	r.restoring[id] = call
+	r.mx.Unlock()
+
+	call.chat, call.err = r.restoreChat(id, store)
+
+	r.mx.Lock()
+	delete(r.restoring, id)
+	r.mx.Unlock()
+
+	close(call.done)
+
+	return call.chat, call.err
+}
+
+func (r *Registry) restoreChat(id string, store RestoreStore) (*Chat, error) {
 	savedChat, err := store.GetChat(id)
 	if err != nil {
 		if errors.Is(err, entity.ErrNotFound) {

--- a/internal/chat/chatslist.go
+++ b/internal/chat/chatslist.go
@@ -1,65 +1,129 @@
 package chat
 
 import (
+	"errors"
 	"log"
 	"sync"
+
+	"technochat/pkg/entity"
 )
 
-var chatsList = newChatsList()
-
-type ChatsList struct {
+type Registry struct {
 	chats map[string]*Chat
+	store RestoreStore
 	mx    sync.Mutex
 }
 
-func newChatsList() *ChatsList {
-	return &ChatsList{
+type RestoreStore interface {
+	StateStore
+	GetChat(chatID string) (entity.Chat, error)
+	DeleteChat(chatID string) error
+}
+
+func NewRegistry(store RestoreStore) *Registry {
+	return &Registry{
 		chats: make(map[string]*Chat),
+		store: store,
 	}
 }
 
-func AddChat(c *Chat) {
-	chatsList.mx.Lock()
-	chatsList.chats[c.ID] = c
-	chatsList.mx.Unlock()
+func (r *Registry) AddChat(c *Chat) {
+	r.mx.Lock()
+	r.chats[c.ID] = c
+	r.mx.Unlock()
 }
 
-func AddChatIfAbsent(c *Chat) (*Chat, bool) {
-	chatsList.mx.Lock()
-	defer chatsList.mx.Unlock()
+func (r *Registry) AddChatIfAbsent(c *Chat) (*Chat, bool) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
 
-	existingChat, ok := chatsList.chats[c.ID]
+	existingChat, ok := r.chats[c.ID]
 	if ok {
 		return existingChat, false
 	}
 
-	chatsList.chats[c.ID] = c
+	r.chats[c.ID] = c
 
 	return c, true
 }
 
-func GetChat(id string) *Chat {
-	chatsList.mx.Lock()
-	defer chatsList.mx.Unlock()
+func (r *Registry) GetChat(id string) (*Chat, error) {
+	r.mx.Lock()
+	c := r.chats[id]
+	store := r.store
+	r.mx.Unlock()
 
-	return chatsList.chats[id]
+	if c != nil || store == nil {
+		return c, nil
+	}
+
+	savedChat, err := store.GetChat(id)
+	if err != nil {
+		if errors.Is(err, entity.ErrNotFound) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	restoredChat := NewChat(newChatOptsFromState(savedChat, store))
+	activeChat, added := r.AddChatIfAbsent(restoredChat)
+	if added {
+		go r.HandleChat(activeChat)
+		log.Printf("info: chat: restored chat %s for %d people, joins left: %d",
+			activeChat.ID, savedChat.MaxUsers, activeChat.RestJoins())
+	}
+
+	return activeChat, nil
 }
 
-func DelChat(id string) {
-	chatsList.mx.Lock()
-	defer chatsList.mx.Unlock()
+func (r *Registry) DelChat(id string) {
+	r.mx.Lock()
+	defer r.mx.Unlock()
 
-	c, ok := chatsList.chats[id]
+	c, ok := r.chats[id]
 	if !ok {
 		return
 	}
 
 	log.Printf("info: chat: deleting chat [%s]", c.ID)
-	delete(chatsList.chats, c.ID)
+	delete(r.chats, c.ID)
 }
 
-func HandleChat(c *Chat) {
+func (r *Registry) HandleChat(c *Chat) {
 	c.Routine()
 
-	DelChat(c.ID)
+	r.DelChat(c.ID)
+
+	r.mx.Lock()
+	store := r.store
+	r.mx.Unlock()
+
+	if store == nil {
+		return
+	}
+
+	if err := store.DeleteChat(c.ID); err != nil {
+		log.Printf("error: chat: could not delete chat %s from db: %v", c.ID, err)
+	}
+}
+
+func newChatOptsFromState(savedChat entity.Chat, store StateStore) NewChatOpts {
+	participants := make([]Participant, 0, len(savedChat.Participants))
+	for _, participant := range savedChat.Participants {
+		participants = append(participants, Participant{
+			ID:             participant.ID,
+			Name:           participant.Name,
+			ReconnectToken: participant.ReconnectToken,
+		})
+	}
+
+	return NewChatOpts{
+		ID:               savedChat.ID,
+		MaxJoins:         savedChat.MaxUsers,
+		RestJoins:        savedChat.RestJoins,
+		RestoreRestJoins: true,
+		Participants:     participants,
+		Store:            store,
+	}
 }

--- a/internal/chat/chatslist_test.go
+++ b/internal/chat/chatslist_test.go
@@ -1,0 +1,184 @@
+package chat
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"technochat/pkg/entity"
+)
+
+type testRestoreStore struct {
+	mx sync.Mutex
+
+	chat     entity.Chat
+	getCalls int
+
+	getStartedOnce sync.Once
+	getStarted     chan struct{}
+	getRelease     chan struct{}
+	deleteDone     chan struct{}
+}
+
+func (s *testRestoreStore) UpdateChat(entity.Chat) error {
+	return nil
+}
+
+func (s *testRestoreStore) GetChat(chatID string) (entity.Chat, error) {
+	s.mx.Lock()
+	s.getCalls++
+	s.mx.Unlock()
+
+	if s.getStarted != nil {
+		s.getStartedOnce.Do(func() {
+			close(s.getStarted)
+		})
+	}
+	if s.getRelease != nil {
+		<-s.getRelease
+	}
+
+	if s.chat.ID != chatID {
+		return entity.Chat{}, entity.ErrNotFound
+	}
+
+	return s.chat, nil
+}
+
+func (s *testRestoreStore) DeleteChat(string) error {
+	if s.deleteDone != nil {
+		close(s.deleteDone)
+	}
+
+	return nil
+}
+
+func (s *testRestoreStore) getCallCount() int {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+
+	return s.getCalls
+}
+
+func TestRegistryRestoresChatLazily(t *testing.T) {
+	const chatID = "registry-lazy-restore-test"
+
+	store := &testRestoreStore{
+		chat: entity.Chat{
+			ID:        chatID,
+			MaxUsers:  1,
+			RestJoins: 0,
+			Participants: []entity.ChatParticipant{
+				{
+					ID:             7,
+					Name:           "restored user",
+					ReconnectToken: "restored-token",
+				},
+			},
+		},
+		deleteDone: make(chan struct{}),
+	}
+	registry := NewRegistry(store)
+
+	restoredChat, err := registry.GetChat(chatID)
+	if err != nil {
+		t.Fatalf("could not restore chat: %v", err)
+	}
+	if restoredChat == nil {
+		t.Fatalf("expected chat to be restored")
+	}
+	if restoredChat.ID != chatID {
+		t.Fatalf("expected restored chat ID %q, got %q", chatID, restoredChat.ID)
+	}
+	if restoredChat.RestJoins() != 0 {
+		t.Fatalf("expected restored joins to be 0, got %d", restoredChat.RestJoins())
+	}
+
+	cachedChat, err := registry.GetChat(chatID)
+	if err != nil {
+		t.Fatalf("could not get cached chat: %v", err)
+	}
+	if cachedChat != restoredChat {
+		t.Fatalf("expected registry to return cached chat")
+	}
+	if store.getCallCount() != 1 {
+		t.Fatalf("expected one store read, got %d", store.getCallCount())
+	}
+
+	stopRegistryChat(t, restoredChat, store.deleteDone)
+}
+
+func TestRegistryCoalescesConcurrentLazyRestore(t *testing.T) {
+	const chatID = "registry-concurrent-restore-test"
+	const callers = 10
+
+	store := &testRestoreStore{
+		chat: entity.Chat{
+			ID:        chatID,
+			MaxUsers:  1,
+			RestJoins: 0,
+			Participants: []entity.ChatParticipant{
+				{
+					ID:             7,
+					Name:           "restored user",
+					ReconnectToken: "restored-token",
+				},
+			},
+		},
+		getStarted: make(chan struct{}),
+		getRelease: make(chan struct{}),
+		deleteDone: make(chan struct{}),
+	}
+	registry := NewRegistry(store)
+
+	results := make(chan *Chat, callers)
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			restoredChat, err := registry.GetChat(chatID)
+			results <- restoredChat
+			errs <- err
+		}()
+	}
+
+	<-store.getStarted
+	time.Sleep(50 * time.Millisecond)
+	close(store.getRelease)
+
+	var firstChat *Chat
+	for i := 0; i < callers; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("could not restore chat: %v", err)
+		}
+
+		restoredChat := <-results
+		if restoredChat == nil {
+			t.Fatalf("expected restored chat")
+		}
+		if firstChat == nil {
+			firstChat = restoredChat
+			continue
+		}
+		if restoredChat != firstChat {
+			t.Fatalf("expected all callers to get the same chat instance")
+		}
+	}
+
+	if store.getCallCount() != 1 {
+		t.Fatalf("expected concurrent restore to read store once, got %d reads", store.getCallCount())
+	}
+
+	stopRegistryChat(t, firstChat, store.deleteDone)
+}
+
+func stopRegistryChat(t *testing.T, c *Chat, done chan struct{}) {
+	t.Helper()
+
+	c.TriggerShutdown()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for restored chat shutdown")
+	}
+}

--- a/internal/chat/user.go
+++ b/internal/chat/user.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"time"
 
@@ -25,6 +26,15 @@ func (c *Chat) AddUser(ws *websocket.Conn) (*user.User, error) {
 	}
 
 	c.restJoins--
+	if c.store != nil {
+		if err := c.store.UpdateChat(c.stateLocked()); err != nil {
+			c.restJoins++
+			delete(c.participants, participant.ReconnectToken)
+			c.correspsMx.Unlock()
+
+			return nil, fmt.Errorf("could not persist chat state: %w", err)
+		}
+	}
 	c.correspsMx.Unlock()
 
 	return c.connectParticipant(ws, participant), nil
@@ -36,6 +46,9 @@ func (c *Chat) ReconnectUser(ws *websocket.Conn, reconnectToken string) (*user.U
 	c.correspsMx.RUnlock()
 	if !ok {
 		return nil, ErrInvalidReconnectToken
+	}
+	if err := c.persistState(); err != nil {
+		return nil, fmt.Errorf("could not persist chat state: %w", err)
 	}
 
 	return c.connectParticipant(ws, participant), nil

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,4 +13,9 @@ type DB interface {
 	AddImage(image entity.Image) error
 	GetImage(imageID string) (entity.Image, error)
 	DeleteImage(imageID string) error
+
+	AddChat(chat entity.Chat) error
+	UpdateChat(chat entity.Chat) error
+	GetChats() ([]entity.Chat, error)
+	DeleteChat(chatID string) error
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -16,6 +16,6 @@ type DB interface {
 
 	AddChat(chat entity.Chat) error
 	UpdateChat(chat entity.Chat) error
-	GetChats() ([]entity.Chat, error)
+	GetChat(chatID string) (entity.Chat, error)
 	DeleteChat(chatID string) error
 }

--- a/internal/db/redis/chat.go
+++ b/internal/db/redis/chat.go
@@ -1,0 +1,182 @@
+package redis
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/mediocregopher/radix.v2/redis"
+
+	"technochat/pkg/entity"
+)
+
+func newChatKey(id string) string {
+	return fmt.Sprintf("%s:%s", chatKeyPrefix, id)
+}
+
+func newChatFromRedis(id string, redisResp map[string]string) (entity.Chat, error) {
+	maxUsers, err := strconv.Atoi(redisResp[chatMaxUsersKey])
+	if err != nil {
+		return entity.Chat{}, fmt.Errorf("invalid chat: max_users is invalid: %w", err)
+	}
+
+	restJoins, err := strconv.Atoi(redisResp[chatRestJoinsKey])
+	if err != nil {
+		return entity.Chat{}, fmt.Errorf("invalid chat: rest_joins is invalid: %w", err)
+	}
+
+	if id == "" {
+		return entity.Chat{}, fmt.Errorf("invalid chat: id is missing")
+	}
+	if maxUsers < 0 {
+		return entity.Chat{}, fmt.Errorf("invalid chat %s: max_users is negative", id)
+	}
+	if restJoins < 0 {
+		return entity.Chat{}, fmt.Errorf("invalid chat %s: rest_joins is negative", id)
+	}
+	if restJoins > maxUsers {
+		return entity.Chat{}, fmt.Errorf("invalid chat %s: rest_joins exceeds max_users", id)
+	}
+
+	participants := []entity.ChatParticipant{}
+	if participantsJSON := redisResp[chatParticipantsKey]; participantsJSON != "" {
+		if err := json.Unmarshal([]byte(participantsJSON), &participants); err != nil {
+			return entity.Chat{}, fmt.Errorf("invalid chat %s: participants are invalid: %w", id, err)
+		}
+	}
+
+	return entity.Chat{
+		ID:           id,
+		MaxUsers:     maxUsers,
+		RestJoins:    restJoins,
+		Participants: participants,
+	}, nil
+}
+
+func (r *Redis) saveChat(chat entity.Chat) error {
+	if chat.ID == "" {
+		return fmt.Errorf("could not save chat: id is missing")
+	}
+	if chat.TTL <= 0 {
+		return fmt.Errorf("could not save chat %s: TTL must be positive", chat.ID)
+	}
+
+	key := newChatKey(chat.ID)
+	participantsJSON, err := json.Marshal(chat.Participants)
+	if err != nil {
+		return fmt.Errorf("could not marshal chat %s participants: %w", chat.ID, err)
+	}
+
+	if err := r.pool.Cmd(
+		"HMSET", key,
+		chatMaxUsersKey, chat.MaxUsers,
+		chatRestJoinsKey, chat.RestJoins,
+		chatParticipantsKey, string(participantsJSON),
+	).Err; err != nil {
+		return fmt.Errorf("could not save chat %s: %w", chat.ID, err)
+	}
+
+	if err := r.pool.Cmd("EXPIRE", key, chat.TTL).Err; err != nil {
+		if delErr := r.pool.Cmd("DEL", key).Err; delErr != nil {
+			return fmt.Errorf("could not set TTL for chat %s and cleanup failed: %w", chat.ID, delErr)
+		}
+
+		return fmt.Errorf("could not set TTL for chat %s: %w", chat.ID, err)
+	}
+
+	return nil
+}
+
+func (r *Redis) AddChat(chat entity.Chat) error {
+	return r.saveChat(chat)
+}
+
+func (r *Redis) UpdateChat(chat entity.Chat) error {
+	return r.saveChat(chat)
+}
+
+func (r *Redis) GetChats() ([]entity.Chat, error) {
+	const scanCount = 100
+
+	cursor := "0"
+	chats := []entity.Chat{}
+
+	for {
+		resp := r.pool.Cmd("SCAN", cursor, "MATCH", newChatKey("*"), "COUNT", scanCount)
+		if err := resp.Err; err != nil {
+			return nil, fmt.Errorf("could not scan chats: %w", err)
+		}
+
+		parts, err := resp.Array()
+		if err != nil {
+			return nil, fmt.Errorf("could not parse chats scan response: %w", err)
+		}
+		if len(parts) != 2 {
+			return nil, fmt.Errorf(
+				"could not parse chats scan response: expected 2 parts, got %d", len(parts),
+			)
+		}
+
+		cursor, err = parts[0].Str()
+		if err != nil {
+			return nil, fmt.Errorf("could not parse chats scan cursor: %w", err)
+		}
+
+		keys, err := parts[1].List()
+		if err != nil {
+			return nil, fmt.Errorf("could not parse chats scan keys: %w", err)
+		}
+
+		for _, key := range keys {
+			id := strings.TrimPrefix(key, chatKeyPrefix+":")
+			if id == key {
+				continue
+			}
+
+			chatResp := r.pool.Cmd("HGETALL", key)
+			if err := chatResp.Err; err != nil {
+				if err == redis.ErrRespNil {
+					continue
+				}
+
+				return nil, fmt.Errorf("could not get chat %s: %w", id, err)
+			}
+
+			chatMap, err := chatResp.Map()
+			if err != nil {
+				return nil, fmt.Errorf("could not parse chat %s: %w", id, err)
+			}
+			if len(chatMap) == 0 {
+				continue
+			}
+
+			chat, err := newChatFromRedis(id, chatMap)
+			if err != nil {
+				return nil, err
+			}
+
+			chats = append(chats, chat)
+		}
+
+		if cursor == "0" {
+			break
+		}
+	}
+
+	return chats, nil
+}
+
+func (r *Redis) DeleteChat(chatID string) error {
+	key := newChatKey(chatID)
+
+	if err := r.pool.Cmd("DEL", key).Err; err != nil {
+		if err == redis.ErrRespNil {
+			return entity.ErrNotFound
+		}
+
+		return fmt.Errorf("could not delete chat with ID %s: %w", chatID, err)
+	}
+
+	return nil
+}

--- a/internal/db/redis/chat.go
+++ b/internal/db/redis/chat.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/mediocregopher/radix.v2/redis"
 
@@ -96,75 +95,27 @@ func (r *Redis) UpdateChat(chat entity.Chat) error {
 	return r.saveChat(chat)
 }
 
-func (r *Redis) GetChats() ([]entity.Chat, error) {
-	const scanCount = 100
+func (r *Redis) GetChat(chatID string) (entity.Chat, error) {
+	key := newChatKey(chatID)
 
-	cursor := "0"
-	chats := []entity.Chat{}
-
-	for {
-		resp := r.pool.Cmd("SCAN", cursor, "MATCH", newChatKey("*"), "COUNT", scanCount)
-		if err := resp.Err; err != nil {
-			return nil, fmt.Errorf("could not scan chats: %w", err)
+	resp := r.pool.Cmd("HGETALL", key)
+	if err := resp.Err; err != nil {
+		if err == redis.ErrRespNil {
+			return entity.Chat{}, entity.ErrNotFound
 		}
 
-		parts, err := resp.Array()
-		if err != nil {
-			return nil, fmt.Errorf("could not parse chats scan response: %w", err)
-		}
-		if len(parts) != 2 {
-			return nil, fmt.Errorf(
-				"could not parse chats scan response: expected 2 parts, got %d", len(parts),
-			)
-		}
-
-		cursor, err = parts[0].Str()
-		if err != nil {
-			return nil, fmt.Errorf("could not parse chats scan cursor: %w", err)
-		}
-
-		keys, err := parts[1].List()
-		if err != nil {
-			return nil, fmt.Errorf("could not parse chats scan keys: %w", err)
-		}
-
-		for _, key := range keys {
-			id := strings.TrimPrefix(key, chatKeyPrefix+":")
-			if id == key {
-				continue
-			}
-
-			chatResp := r.pool.Cmd("HGETALL", key)
-			if err := chatResp.Err; err != nil {
-				if err == redis.ErrRespNil {
-					continue
-				}
-
-				return nil, fmt.Errorf("could not get chat %s: %w", id, err)
-			}
-
-			chatMap, err := chatResp.Map()
-			if err != nil {
-				return nil, fmt.Errorf("could not parse chat %s: %w", id, err)
-			}
-			if len(chatMap) == 0 {
-				continue
-			}
-
-			chat, err := newChatFromRedis(id, chatMap)
-			if err != nil {
-				return nil, err
-			}
-
-			chats = append(chats, chat)
-		}
-
-		if cursor == "0" {
-			break
-		}
+		return entity.Chat{}, fmt.Errorf("could not get chat %s: %w", chatID, err)
 	}
 
-	return chats, nil
+	chatMap, err := resp.Map()
+	if err != nil {
+		return entity.Chat{}, fmt.Errorf("could not parse chat %s: %w", chatID, err)
+	}
+	if len(chatMap) == 0 {
+		return entity.Chat{}, entity.ErrNotFound
+	}
+
+	return newChatFromRedis(chatID, chatMap)
 }
 
 func (r *Redis) DeleteChat(chatID string) error {

--- a/internal/db/redis/chat_integration_test.go
+++ b/internal/db/redis/chat_integration_test.go
@@ -1,0 +1,101 @@
+//go:build integration_tests
+// +build integration_tests
+
+package redis
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"technochat/pkg/entity"
+)
+
+func TestChatTTLIsSetRefreshedAndExpires(t *testing.T) {
+	addr := os.Getenv("TECHNOCHAT_TEST_REDIS_ADDR")
+	if addr == "" {
+		t.Skip("TECHNOCHAT_TEST_REDIS_ADDR is not set")
+	}
+
+	r := NewRedis(addr)
+	r.Init()
+	defer r.pool.Empty()
+
+	chatID := "ttl-integration-test"
+	key := newChatKey(chatID)
+	if err := r.pool.Cmd("DEL", key).Err; err != nil {
+		t.Fatalf("could not cleanup chat key before test: %v", err)
+	}
+	defer r.pool.Cmd("DEL", key)
+
+	chat := entity.Chat{
+		ID:        chatID,
+		MaxUsers:  2,
+		RestJoins: 2,
+		TTL:       3,
+	}
+	if err := r.AddChat(chat); err != nil {
+		t.Fatalf("could not add chat: %v", err)
+	}
+
+	initialTTL := redisTTL(t, r, key)
+	if initialTTL <= 0 {
+		t.Fatalf("expected positive chat TTL, got %d", initialTTL)
+	}
+
+	time.Sleep(1500 * time.Millisecond)
+
+	if err := r.UpdateChat(chat); err != nil {
+		t.Fatalf("could not update chat: %v", err)
+	}
+
+	refreshedTTL := redisTTL(t, r, key)
+	if refreshedTTL < 2 {
+		t.Fatalf("expected refreshed chat TTL to be at least 2 seconds, got %d", refreshedTTL)
+	}
+
+	time.Sleep(2 * time.Second)
+
+	if exists := redisExists(t, r, key); !exists {
+		t.Fatalf("expected chat key to exist after TTL refresh")
+	}
+
+	waitForRedisKeyMissing(t, r, key)
+}
+
+func redisTTL(t *testing.T, r *Redis, key string) int {
+	t.Helper()
+
+	ttl, err := r.pool.Cmd("TTL", key).Int()
+	if err != nil {
+		t.Fatalf("could not read TTL for %s: %v", key, err)
+	}
+
+	return ttl
+}
+
+func redisExists(t *testing.T, r *Redis, key string) bool {
+	t.Helper()
+
+	exists, err := r.pool.Cmd("EXISTS", key).Int()
+	if err != nil {
+		t.Fatalf("could not check key %s existence: %v", key, err)
+	}
+
+	return exists == 1
+}
+
+func waitForRedisKeyMissing(t *testing.T, r *Redis, key string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if !redisExists(t, r, key) {
+			return
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("expected chat key %s to expire", key)
+}

--- a/internal/db/redis/chat_test.go
+++ b/internal/db/redis/chat_test.go
@@ -1,0 +1,47 @@
+package redis
+
+import (
+	"encoding/json"
+	"testing"
+
+	"technochat/pkg/entity"
+)
+
+func TestNewChatFromRedisRestoresParticipants(t *testing.T) {
+	participants := []entity.ChatParticipant{
+		{
+			ID:             42,
+			Name:           "restored user",
+			ReconnectToken: "reconnect-token",
+		},
+	}
+	participantsJSON, err := json.Marshal(participants)
+	if err != nil {
+		t.Fatalf("could not marshal participants: %v", err)
+	}
+
+	chat, err := newChatFromRedis("chat-id", map[string]string{
+		chatMaxUsersKey:     "3",
+		chatRestJoinsKey:    "2",
+		chatParticipantsKey: string(participantsJSON),
+	})
+	if err != nil {
+		t.Fatalf("could not restore chat: %v", err)
+	}
+
+	if chat.ID != "chat-id" {
+		t.Fatalf("expected chat id to be restored, got %q", chat.ID)
+	}
+	if chat.MaxUsers != 3 {
+		t.Fatalf("expected max users 3, got %d", chat.MaxUsers)
+	}
+	if chat.RestJoins != 2 {
+		t.Fatalf("expected rest joins 2, got %d", chat.RestJoins)
+	}
+	if len(chat.Participants) != 1 {
+		t.Fatalf("expected 1 participant, got %d", len(chat.Participants))
+	}
+	if chat.Participants[0] != participants[0] {
+		t.Fatalf("expected participant %#v, got %#v", participants[0], chat.Participants[0])
+	}
+}

--- a/internal/db/redis/redis.go
+++ b/internal/db/redis/redis.go
@@ -13,11 +13,16 @@ const (
 const (
 	msgKeyPrefix   = "msg"
 	imageKeyPrefix = "img"
+	chatKeyPrefix  = "chat"
 
 	msgTextKey   = "text"
 	msgImagesKey = "imgs"
 
 	imgBodyKey = "body"
+
+	chatMaxUsersKey     = "max_users"
+	chatRestJoinsKey    = "rest_joins"
+	chatParticipantsKey = "participants"
 )
 
 type Redis struct {

--- a/internal/http/chat.go
+++ b/internal/http/chat.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"technochat/internal/chat"
 	"technochat/internal/chat/message"
 	"technochat/internal/chat/user"
+	"technochat/pkg/entity"
 )
 
 type ChatInitRequest struct {
@@ -66,37 +68,41 @@ func (s *Server) chatInit(r *http.Request) (int, interface{}, error) {
 	return http.StatusOK, resp, nil
 }
 
-func (s *Server) restoreChats() error {
-	savedChats, err := s.db.GetChats()
+func (s *Server) restoreChat(chatID string) (*chat.Chat, error) {
+	savedChat, err := s.db.GetChat(chatID)
 	if err != nil {
-		return err
-	}
-
-	for _, savedChat := range savedChats {
-		participants := make([]chat.Participant, 0, len(savedChat.Participants))
-		for _, participant := range savedChat.Participants {
-			participants = append(participants, chat.Participant{
-				ID:             participant.ID,
-				Name:           participant.Name,
-				ReconnectToken: participant.ReconnectToken,
-			})
+		if errors.Is(err, entity.ErrNotFound) {
+			return nil, nil
 		}
 
-		restoredChat := chat.NewChat(chat.NewChatOpts{
-			ID:               savedChat.ID,
-			MaxJoins:         savedChat.MaxUsers,
-			RestJoins:        savedChat.RestJoins,
-			RestoreRestJoins: true,
-			Participants:     participants,
-			Store:            s.db,
-		})
-
-		s.startChat(restoredChat)
-		log.Printf("info: chat: restored chat %s for %d people, joins left: %d",
-			restoredChat.ID, savedChat.MaxUsers, restoredChat.RestJoins())
+		return nil, err
 	}
 
-	return nil
+	participants := make([]chat.Participant, 0, len(savedChat.Participants))
+	for _, participant := range savedChat.Participants {
+		participants = append(participants, chat.Participant{
+			ID:             participant.ID,
+			Name:           participant.Name,
+			ReconnectToken: participant.ReconnectToken,
+		})
+	}
+
+	restoredChat := chat.NewChat(chat.NewChatOpts{
+		ID:               savedChat.ID,
+		MaxJoins:         savedChat.MaxUsers,
+		RestJoins:        savedChat.RestJoins,
+		RestoreRestJoins: true,
+		Participants:     participants,
+		Store:            s.db,
+	})
+
+	activeChat, started := s.startChatIfAbsent(restoredChat)
+	if started {
+		log.Printf("info: chat: restored chat %s for %d people, joins left: %d",
+			activeChat.ID, savedChat.MaxUsers, activeChat.RestJoins())
+	}
+
+	return activeChat, nil
 }
 
 func (s *Server) startChat(c *chat.Chat) {
@@ -109,6 +115,23 @@ func (s *Server) startChat(c *chat.Chat) {
 			log.Printf("error: chat: could not delete chat %s from db: %v", c.ID, err)
 		}
 	}()
+}
+
+func (s *Server) startChatIfAbsent(c *chat.Chat) (*chat.Chat, bool) {
+	activeChat, added := chat.AddChatIfAbsent(c)
+	if !added {
+		return activeChat, false
+	}
+
+	go func() {
+		chat.HandleChat(c)
+
+		if err := s.db.DeleteChat(c.ID); err != nil {
+			log.Printf("error: chat: could not delete chat %s from db: %v", c.ID, err)
+		}
+	}()
+
+	return activeChat, true
 }
 
 func (s *Server) chatConnect(w http.ResponseWriter, r *http.Request) {
@@ -134,12 +157,27 @@ func (s *Server) chatConnectWithMode(w http.ResponseWriter, r *http.Request, rec
 
 	chatIDStr := r.FormValue("id")
 	remoteAddr := getRealRemoteAddr(r)
+	chatIDForLog := sanitizeClientLogValue(chatIDStr)
+	remoteAddrForLog := sanitizeClientLogValue(remoteAddr)
 
 	c := chat.GetChat(chatIDStr)
 	if c == nil {
-		log.Printf("info: chat: chat %s does not exist for %s", chatIDStr, remoteAddr)
-		sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
-		return
+		c, err = s.restoreChat(chatIDStr)
+		if err != nil {
+			//nolint:gosec // Chat ID and remote address are sanitized before logging.
+			log.Printf(
+				"error: chat: could not restore chat %s for %s: %v",
+				chatIDForLog, remoteAddrForLog, err,
+			)
+			sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
+			return
+		}
+		if c == nil {
+			//nolint:gosec // Chat ID and remote address are sanitized before logging.
+			log.Printf("info: chat: chat %s does not exist for %s", chatIDForLog, remoteAddrForLog)
+			sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
+			return
+		}
 	}
 
 	usr, err := connectChatUser(c, ws, r, reconnect)
@@ -156,13 +194,16 @@ func (s *Server) chatConnectWithMode(w http.ResponseWriter, r *http.Request, rec
 			eventID = message.EventConnInitInvalidReconnectToken
 		}
 
-		log.Printf("%s: chat: could not add new user to chat %s: %v", level, chatIDStr, err)
+		//nolint:gosec // Chat ID is sanitized before logging.
+		log.Printf("%s: chat: could not add new user to chat %s: %v", level, chatIDForLog, err)
 		sendChatInitEvent(ws, eventID)
 		return
 	}
 
+	userNameForLog := sanitizeClientLogValue(usr.Name)
+	//nolint:gosec // User name, chat ID and remote address are sanitized before logging.
 	log.Printf("info: chat: connected user [%d %s] to chat %s from %s, joins left after add: %d",
-		usr.ID, usr.Name, chatIDStr, remoteAddr, c.RestJoins())
+		usr.ID, userNameForLog, chatIDForLog, remoteAddrForLog, c.RestJoins())
 
 	usr.Routine()
 

--- a/internal/http/chat.go
+++ b/internal/http/chat.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -13,7 +12,6 @@ import (
 	"technochat/internal/chat"
 	"technochat/internal/chat/message"
 	"technochat/internal/chat/user"
-	"technochat/pkg/entity"
 )
 
 type ChatInitRequest struct {
@@ -68,70 +66,9 @@ func (s *Server) chatInit(r *http.Request) (int, interface{}, error) {
 	return http.StatusOK, resp, nil
 }
 
-func (s *Server) restoreChat(chatID string) (*chat.Chat, error) {
-	savedChat, err := s.db.GetChat(chatID)
-	if err != nil {
-		if errors.Is(err, entity.ErrNotFound) {
-			return nil, nil
-		}
-
-		return nil, err
-	}
-
-	participants := make([]chat.Participant, 0, len(savedChat.Participants))
-	for _, participant := range savedChat.Participants {
-		participants = append(participants, chat.Participant{
-			ID:             participant.ID,
-			Name:           participant.Name,
-			ReconnectToken: participant.ReconnectToken,
-		})
-	}
-
-	restoredChat := chat.NewChat(chat.NewChatOpts{
-		ID:               savedChat.ID,
-		MaxJoins:         savedChat.MaxUsers,
-		RestJoins:        savedChat.RestJoins,
-		RestoreRestJoins: true,
-		Participants:     participants,
-		Store:            s.db,
-	})
-
-	activeChat, started := s.startChatIfAbsent(restoredChat)
-	if started {
-		log.Printf("info: chat: restored chat %s for %d people, joins left: %d",
-			activeChat.ID, savedChat.MaxUsers, activeChat.RestJoins())
-	}
-
-	return activeChat, nil
-}
-
 func (s *Server) startChat(c *chat.Chat) {
-	chat.AddChat(c)
-
-	go func() {
-		chat.HandleChat(c)
-
-		if err := s.db.DeleteChat(c.ID); err != nil {
-			log.Printf("error: chat: could not delete chat %s from db: %v", c.ID, err)
-		}
-	}()
-}
-
-func (s *Server) startChatIfAbsent(c *chat.Chat) (*chat.Chat, bool) {
-	activeChat, added := chat.AddChatIfAbsent(c)
-	if !added {
-		return activeChat, false
-	}
-
-	go func() {
-		chat.HandleChat(c)
-
-		if err := s.db.DeleteChat(c.ID); err != nil {
-			log.Printf("error: chat: could not delete chat %s from db: %v", c.ID, err)
-		}
-	}()
-
-	return activeChat, true
+	s.chatRegistry().AddChat(c)
+	go s.chatRegistry().HandleChat(c)
 }
 
 func (s *Server) chatConnect(w http.ResponseWriter, r *http.Request) {
@@ -160,24 +97,21 @@ func (s *Server) chatConnectWithMode(w http.ResponseWriter, r *http.Request, rec
 	chatIDForLog := sanitizeClientLogValue(chatIDStr)
 	remoteAddrForLog := sanitizeClientLogValue(remoteAddr)
 
-	c := chat.GetChat(chatIDStr)
+	c, err := s.chatRegistry().GetChat(chatIDStr)
+	if err != nil {
+		//nolint:gosec // Chat ID and remote address are sanitized before logging.
+		log.Printf(
+			"error: chat: could not get chat %s for %s: %v",
+			chatIDForLog, remoteAddrForLog, err,
+		)
+		sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
+		return
+	}
 	if c == nil {
-		c, err = s.restoreChat(chatIDStr)
-		if err != nil {
-			//nolint:gosec // Chat ID and remote address are sanitized before logging.
-			log.Printf(
-				"error: chat: could not restore chat %s for %s: %v",
-				chatIDForLog, remoteAddrForLog, err,
-			)
-			sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
-			return
-		}
-		if c == nil {
-			//nolint:gosec // Chat ID and remote address are sanitized before logging.
-			log.Printf("info: chat: chat %s does not exist for %s", chatIDForLog, remoteAddrForLog)
-			sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
-			return
-		}
+		//nolint:gosec // Chat ID and remote address are sanitized before logging.
+		log.Printf("info: chat: chat %s does not exist for %s", chatIDForLog, remoteAddrForLog)
+		sendChatInitEvent(ws, message.EventConnInitNoSuchChat)
+		return
 	}
 
 	usr, err := connectChatUser(c, ws, r, reconnect)

--- a/internal/http/chat.go
+++ b/internal/http/chat.go
@@ -49,18 +49,66 @@ func (s *Server) chatInit(r *http.Request) (int, interface{}, error) {
 	newChat := chat.NewChat(chat.NewChatOpts{
 		ID:       chatID.String(),
 		MaxJoins: req.MaxUsers,
+		Store:    s.db,
 	})
 
-	chat.AddChat(newChat)
+	if err := s.db.AddChat(newChat.State()); err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	s.startChat(newChat)
 	log.Printf("info: chat: started a new chat %s for %d people", newChat.ID, newChat.RestJoins())
 
 	resp := ChatInitResponse{
 		ID: newChat.ID,
 	}
 
-	go chat.HandleChat(newChat)
-
 	return http.StatusOK, resp, nil
+}
+
+func (s *Server) restoreChats() error {
+	savedChats, err := s.db.GetChats()
+	if err != nil {
+		return err
+	}
+
+	for _, savedChat := range savedChats {
+		participants := make([]chat.Participant, 0, len(savedChat.Participants))
+		for _, participant := range savedChat.Participants {
+			participants = append(participants, chat.Participant{
+				ID:             participant.ID,
+				Name:           participant.Name,
+				ReconnectToken: participant.ReconnectToken,
+			})
+		}
+
+		restoredChat := chat.NewChat(chat.NewChatOpts{
+			ID:               savedChat.ID,
+			MaxJoins:         savedChat.MaxUsers,
+			RestJoins:        savedChat.RestJoins,
+			RestoreRestJoins: true,
+			Participants:     participants,
+			Store:            s.db,
+		})
+
+		s.startChat(restoredChat)
+		log.Printf("info: chat: restored chat %s for %d people, joins left: %d",
+			restoredChat.ID, savedChat.MaxUsers, restoredChat.RestJoins())
+	}
+
+	return nil
+}
+
+func (s *Server) startChat(c *chat.Chat) {
+	chat.AddChat(c)
+
+	go func() {
+		chat.HandleChat(c)
+
+		if err := s.db.DeleteChat(c.ID); err != nil {
+			log.Printf("error: chat: could not delete chat %s from db: %v", c.ID, err)
+		}
+	}()
 }
 
 func (s *Server) chatConnect(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/chat_test.go
+++ b/internal/http/chat_test.go
@@ -1,0 +1,237 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"technochat/internal/chat"
+	"technochat/internal/chat/message"
+	"technochat/pkg/entity"
+)
+
+type testDB struct {
+	mx sync.Mutex
+
+	chat      entity.Chat
+	addChat   entity.Chat
+	addErr    error
+	getCalls  int
+	updateNum int
+}
+
+func (db *testDB) Init()     {}
+func (db *testDB) Shutdown() {}
+
+func (db *testDB) AddMessage(entity.Message) error { return nil }
+func (db *testDB) GetMessage(string) (entity.Message, error) {
+	return entity.Message{}, entity.ErrNotFound
+}
+func (db *testDB) DeleteMessage(string) error            { return nil }
+func (db *testDB) AddImage(entity.Image) error           { return nil }
+func (db *testDB) GetImage(string) (entity.Image, error) { return entity.Image{}, entity.ErrNotFound }
+func (db *testDB) DeleteImage(string) error              { return nil }
+func (db *testDB) DeleteChat(string) error               { return nil }
+func (db *testDB) GetChat(chatID string) (entity.Chat, error) {
+	return db.withGetChat(chatID)
+}
+func (db *testDB) AddChat(chat entity.Chat) error {
+	return db.withAddChat(chat)
+}
+
+func (db *testDB) UpdateChat(entity.Chat) error {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	db.updateNum++
+
+	return nil
+}
+func (db *testDB) withGetChat(chatID string) (entity.Chat, error) {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	db.getCalls++
+	if db.chat.ID != chatID {
+		return entity.Chat{}, entity.ErrNotFound
+	}
+
+	return db.chat, nil
+}
+
+func (db *testDB) withAddChat(chat entity.Chat) error {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	db.addChat = chat
+
+	return db.addErr
+}
+
+func (db *testDB) updateCount() int {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	return db.updateNum
+}
+
+func (db *testDB) getChatCalls() int {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	return db.getCalls
+}
+
+func (db *testDB) addedChat() entity.Chat {
+	db.mx.Lock()
+	defer db.mx.Unlock()
+
+	return db.addChat
+}
+
+func TestChatConnectRestoresChatLazily(t *testing.T) {
+	const chatID = "lazy-restore-chat-test"
+	const reconnectToken = "lazy-restore-token"
+
+	db := &testDB{
+		chat: entity.Chat{
+			ID:        chatID,
+			MaxUsers:  1,
+			RestJoins: 0,
+			Participants: []entity.ChatParticipant{
+				{
+					ID:             7,
+					Name:           "restored user",
+					ReconnectToken: reconnectToken,
+				},
+			},
+		},
+	}
+	s := &Server{db: db}
+
+	server := httptest.NewServer(http.HandlerFunc(s.chatReconnect))
+	defer server.Close()
+
+	client := dialTestWebsocket(t, server.URL, "?id="+url.QueryEscape(chatID)+"&reconnect_token="+reconnectToken)
+	defer client.Close()
+
+	init := readTestConnInit(t, client)
+	if init.Name != "restored user" {
+		t.Fatalf("expected restored user name, got %q", init.Name)
+	}
+	if init.ReconnectToken != reconnectToken {
+		t.Fatalf("expected reconnect token to stay stable")
+	}
+	if db.getChatCalls() != 1 {
+		t.Fatalf("expected chat to be read lazily once, got %d reads", db.getChatCalls())
+	}
+	if db.updateCount() == 0 {
+		t.Fatalf("expected reconnect to persist restored chat state")
+	}
+
+	restoredChat := chat.GetChat(chatID)
+	if restoredChat == nil {
+		t.Fatalf("expected chat to be registered after lazy restore")
+	}
+	restoredChat.TriggerShutdown()
+}
+
+func TestChatInitDoesNotRegisterChatWhenPersistFails(t *testing.T) {
+	storeErr := errors.New("redis unavailable")
+	db := &testDB{addErr: storeErr}
+	s := &Server{db: db}
+
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/chat/init", strings.NewReader(`{"max_users":"2"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, err := s.chatInit(req)
+	if err == nil {
+		t.Fatalf("expected chat init to fail")
+	}
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("expected store error %q, got %v", storeErr, err)
+	}
+	if code != http.StatusInternalServerError {
+		t.Fatalf("expected status %d, got %d", http.StatusInternalServerError, code)
+	}
+
+	persistedChat := db.addedChat()
+	if persistedChat.ID == "" {
+		t.Fatalf("expected chat init to try persisting a chat")
+	}
+	if activeChat := chat.GetChat(persistedChat.ID); activeChat != nil {
+		activeChat.TriggerShutdown()
+		t.Fatalf("expected failed chat init not to register chat %s in memory", persistedChat.ID)
+	}
+}
+
+type testConnInit struct {
+	Name           string
+	ReconnectToken string
+}
+
+func dialTestWebsocket(t *testing.T, serverURL string, rawQuery string) *websocket.Conn {
+	t.Helper()
+
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + rawQuery
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("could not dial websocket: %v", err)
+	}
+
+	return client
+}
+
+func readTestConnInit(t *testing.T, client *websocket.Conn) testConnInit {
+	t.Helper()
+
+	if err := client.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("could not set read deadline: %v", err)
+	}
+
+	for {
+		var wsMsg message.WSMessage
+		if err := client.ReadJSON(&wsMsg); err != nil {
+			t.Fatalf("could not read websocket message: %v", err)
+		}
+
+		event, ok := wsMsg.Data.(map[string]interface{})
+		if wsMsg.Type != message.WSMsgTypeService || !ok {
+			continue
+		}
+
+		eventID, ok := event["event_id"].(float64)
+		if !ok || message.EventID(eventID) != message.EventConnInitOk {
+			continue
+		}
+
+		eventData, ok := event["event_data"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected conn init event data, got %#v", event["event_data"])
+		}
+
+		name, ok := eventData["name"].(string)
+		if !ok {
+			t.Fatalf("expected conn init name, got %#v", eventData["name"])
+		}
+
+		reconnectToken, ok := eventData["reconnect_token"].(string)
+		if !ok {
+			t.Fatalf("expected conn init reconnect token, got %#v", eventData["reconnect_token"])
+		}
+
+		return testConnInit{
+			Name:           name,
+			ReconnectToken: reconnectToken,
+		}
+	}
+}

--- a/internal/http/chat_test.go
+++ b/internal/http/chat_test.go
@@ -13,11 +13,9 @@ import (
 type testDB struct {
 	mx sync.Mutex
 
-	chat      entity.Chat
-	addChat   entity.Chat
-	addErr    error
-	getCalls  int
-	updateNum int
+	chat    entity.Chat
+	addChat entity.Chat
+	addErr  error
 }
 
 func (db *testDB) Init()     {}
@@ -40,18 +38,12 @@ func (db *testDB) AddChat(chat entity.Chat) error {
 }
 
 func (db *testDB) UpdateChat(entity.Chat) error {
-	db.mx.Lock()
-	defer db.mx.Unlock()
-
-	db.updateNum++
-
 	return nil
 }
 func (db *testDB) withGetChat(chatID string) (entity.Chat, error) {
 	db.mx.Lock()
 	defer db.mx.Unlock()
 
-	db.getCalls++
 	if db.chat.ID != chatID {
 		return entity.Chat{}, entity.ErrNotFound
 	}
@@ -66,20 +58,6 @@ func (db *testDB) withAddChat(chat entity.Chat) error {
 	db.addChat = chat
 
 	return db.addErr
-}
-
-func (db *testDB) updateCount() int {
-	db.mx.Lock()
-	defer db.mx.Unlock()
-
-	return db.updateNum
-}
-
-func (db *testDB) getChatCalls() int {
-	db.mx.Lock()
-	defer db.mx.Unlock()
-
-	return db.getCalls
 }
 
 func (db *testDB) addedChat() entity.Chat {

--- a/internal/http/chat_test.go
+++ b/internal/http/chat_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"technochat/internal/chat"
 	"technochat/internal/chat/message"
 	"technochat/pkg/entity"
 )
@@ -136,7 +135,10 @@ func TestChatConnectRestoresChatLazily(t *testing.T) {
 		t.Fatalf("expected reconnect to persist restored chat state")
 	}
 
-	restoredChat := chat.GetChat(chatID)
+	restoredChat, err := s.chatRegistry().GetChat(chatID)
+	if err != nil {
+		t.Fatalf("could not get restored chat: %v", err)
+	}
 	if restoredChat == nil {
 		t.Fatalf("expected chat to be registered after lazy restore")
 	}
@@ -168,7 +170,11 @@ func TestChatInitDoesNotRegisterChatWhenPersistFails(t *testing.T) {
 	if persistedChat.ID == "" {
 		t.Fatalf("expected chat init to try persisting a chat")
 	}
-	if activeChat := chat.GetChat(persistedChat.ID); activeChat != nil {
+	activeChat, err := s.chatRegistry().GetChat(persistedChat.ID)
+	if err != nil {
+		t.Fatalf("could not get chat from registry: %v", err)
+	}
+	if activeChat != nil {
 		activeChat.TriggerShutdown()
 		t.Fatalf("expected failed chat init not to register chat %s in memory", persistedChat.ID)
 	}

--- a/internal/http/chat_test.go
+++ b/internal/http/chat_test.go
@@ -3,16 +3,10 @@ package http
 import (
 	"errors"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
-	"github.com/gorilla/websocket"
-
-	"technochat/internal/chat/message"
 	"technochat/pkg/entity"
 )
 
@@ -95,56 +89,6 @@ func (db *testDB) addedChat() entity.Chat {
 	return db.addChat
 }
 
-func TestChatConnectRestoresChatLazily(t *testing.T) {
-	const chatID = "lazy-restore-chat-test"
-	const reconnectToken = "lazy-restore-token"
-
-	db := &testDB{
-		chat: entity.Chat{
-			ID:        chatID,
-			MaxUsers:  1,
-			RestJoins: 0,
-			Participants: []entity.ChatParticipant{
-				{
-					ID:             7,
-					Name:           "restored user",
-					ReconnectToken: reconnectToken,
-				},
-			},
-		},
-	}
-	s := &Server{db: db}
-
-	server := httptest.NewServer(http.HandlerFunc(s.chatReconnect))
-	defer server.Close()
-
-	client := dialTestWebsocket(t, server.URL, "?id="+url.QueryEscape(chatID)+"&reconnect_token="+reconnectToken)
-	defer closeTestWebsocket(t, client)
-
-	init := readTestConnInit(t, client)
-	if init.Name != "restored user" {
-		t.Fatalf("expected restored user name, got %q", init.Name)
-	}
-	if init.ReconnectToken != reconnectToken {
-		t.Fatalf("expected reconnect token to stay stable")
-	}
-	if db.getChatCalls() != 1 {
-		t.Fatalf("expected chat to be read lazily once, got %d reads", db.getChatCalls())
-	}
-	if db.updateCount() == 0 {
-		t.Fatalf("expected reconnect to persist restored chat state")
-	}
-
-	restoredChat, err := s.chatRegistry().GetChat(chatID)
-	if err != nil {
-		t.Fatalf("could not get restored chat: %v", err)
-	}
-	if restoredChat == nil {
-		t.Fatalf("expected chat to be registered after lazy restore")
-	}
-	restoredChat.TriggerShutdown()
-}
-
 func TestChatInitDoesNotRegisterChatWhenPersistFails(t *testing.T) {
 	storeErr := errors.New("redis unavailable")
 	db := &testDB{addErr: storeErr}
@@ -177,75 +121,5 @@ func TestChatInitDoesNotRegisterChatWhenPersistFails(t *testing.T) {
 	if activeChat != nil {
 		activeChat.TriggerShutdown()
 		t.Fatalf("expected failed chat init not to register chat %s in memory", persistedChat.ID)
-	}
-}
-
-type testConnInit struct {
-	Name           string
-	ReconnectToken string
-}
-
-func dialTestWebsocket(t *testing.T, serverURL string, rawQuery string) *websocket.Conn {
-	t.Helper()
-
-	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + rawQuery
-	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	if err != nil {
-		t.Fatalf("could not dial websocket: %v", err)
-	}
-
-	return client
-}
-
-func closeTestWebsocket(t *testing.T, client *websocket.Conn) {
-	t.Helper()
-
-	if err := client.Close(); err != nil {
-		t.Fatalf("could not close websocket client: %v", err)
-	}
-}
-
-func readTestConnInit(t *testing.T, client *websocket.Conn) testConnInit {
-	t.Helper()
-
-	if err := client.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
-		t.Fatalf("could not set read deadline: %v", err)
-	}
-
-	for {
-		var wsMsg message.WSMessage
-		if err := client.ReadJSON(&wsMsg); err != nil {
-			t.Fatalf("could not read websocket message: %v", err)
-		}
-
-		event, ok := wsMsg.Data.(map[string]interface{})
-		if wsMsg.Type != message.WSMsgTypeService || !ok {
-			continue
-		}
-
-		eventID, ok := event["event_id"].(float64)
-		if !ok || message.EventID(eventID) != message.EventConnInitOk {
-			continue
-		}
-
-		eventData, ok := event["event_data"].(map[string]interface{})
-		if !ok {
-			t.Fatalf("expected conn init event data, got %#v", event["event_data"])
-		}
-
-		name, ok := eventData["name"].(string)
-		if !ok {
-			t.Fatalf("expected conn init name, got %#v", eventData["name"])
-		}
-
-		reconnectToken, ok := eventData["reconnect_token"].(string)
-		if !ok {
-			t.Fatalf("expected conn init reconnect token, got %#v", eventData["reconnect_token"])
-		}
-
-		return testConnInit{
-			Name:           name,
-			ReconnectToken: reconnectToken,
-		}
 	}
 }

--- a/internal/http/chat_test.go
+++ b/internal/http/chat_test.go
@@ -120,7 +120,7 @@ func TestChatConnectRestoresChatLazily(t *testing.T) {
 	defer server.Close()
 
 	client := dialTestWebsocket(t, server.URL, "?id="+url.QueryEscape(chatID)+"&reconnect_token="+reconnectToken)
-	defer client.Close()
+	defer closeTestWebsocket(t, client)
 
 	init := readTestConnInit(t, client)
 	if init.Name != "restored user" {
@@ -189,6 +189,14 @@ func dialTestWebsocket(t *testing.T, serverURL string, rawQuery string) *websock
 	}
 
 	return client
+}
+
+func closeTestWebsocket(t *testing.T, client *websocket.Conn) {
+	t.Helper()
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("could not close websocket client: %v", err)
+	}
 }
 
 func readTestConnInit(t *testing.T, client *websocket.Conn) testConnInit {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"technochat/internal/chat"
 	"technochat/internal/db"
 )
 
@@ -26,6 +27,7 @@ type Server struct {
 	addr string
 
 	db     db.DB
+	chats  *chat.Registry
 	server *http.Server
 }
 
@@ -39,14 +41,23 @@ type TechnochatHandlerRaw func(*http.Request) (int, []byte, error)
 
 func NewServer(addr string, db db.DB) *Server {
 	return &Server{
-		addr: addr,
-		db:   db,
+		addr:  addr,
+		db:    db,
+		chats: chat.NewRegistry(db),
 		server: &http.Server{
 			Addr:              addr,
 			Handler:           nil,
 			ReadHeaderTimeout: gracefulTime,
 		},
 	}
+}
+
+func (s *Server) chatRegistry() *chat.Registry {
+	if s.chats == nil {
+		s.chats = chat.NewRegistry(s.db)
+	}
+
+	return s.chats
 }
 
 func (s *Server) Init() {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -62,6 +62,10 @@ func (s *Server) Init() {
 	http.HandleFunc("/api/v1/chat/reconnect", s.chatReconnect)
 	http.HandleFunc("/api/v1/client/log", respondAPI(s.clientLog))
 
+	if err := s.restoreChats(); err != nil {
+		log.Fatalln("http: could not restore chats:", err)
+	}
+
 	log.Println("http: successfully initialised")
 }
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -62,10 +62,6 @@ func (s *Server) Init() {
 	http.HandleFunc("/api/v1/chat/reconnect", s.chatReconnect)
 	http.HandleFunc("/api/v1/client/log", respondAPI(s.clientLog))
 
-	if err := s.restoreChats(); err != nil {
-		log.Fatalln("http: could not restore chats:", err)
-	}
-
 	log.Println("http: successfully initialised")
 }
 

--- a/pkg/entity/chat.go
+++ b/pkg/entity/chat.go
@@ -1,0 +1,15 @@
+package entity
+
+type Chat struct {
+	ID           string
+	MaxUsers     int
+	RestJoins    int
+	Participants []ChatParticipant
+	TTL          int
+}
+
+type ChatParticipant struct {
+	ID             int
+	Name           string
+	ReconnectToken string
+}


### PR DESCRIPTION
## Summary

Persist chat room metadata in Redis so active chats can survive backend restarts. The stored state includes join quota, configured capacity, participants, and reconnect tokens, with Redis TTL attached to the chat metadata.

On startup, the backend now initializes Redis before HTTP routes and restores saved chats back into the in-memory chat registry. Chat lifecycle changes update Redis on creation, join, reconnect, and chat activity, and remove the metadata when the chat shuts down normally.

closes #119