### PR TITLE
Pass chat TTL env to container

### DIFF
--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         depends_on:
             - redis
         environment:
+            TECHNOCHAT_CHAT_TTL: "${TECHNOCHAT_CHAT_TTL:-}"
             VAPID_PUBLIC_KEY: "${VAPID_PUBLIC_KEY:-}"
             VAPID_PRIVATE_KEY: "${VAPID_PRIVATE_KEY:-}"
             VAPID_SUBJECT: "${VAPID_SUBJECT:-}"


### PR DESCRIPTION
## What changed

- Pass `TECHNOCHAT_CHAT_TTL` through the base Docker Compose service environment for the `technochat` container.

## Impact

Deployments can now set `TECHNOCHAT_CHAT_TTL` outside the container and have the application receive it instead of falling back to the built-in default.