### PR TITLE
Add configurable RC autodeploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,15 @@ install_autodeploy:
 	systemctl daemon-reload
 	systemctl enable --now autodeploy_technochat.timer
 
+install_autodeploy_rc:
+	mkdir -p /opt/technochat
+	cp -pr . /opt/technochat
+	chmod +x /opt/technochat/dist/autodeploy.sh
+	cp ./dist/autodeploy_technochat_rc.service /etc/systemd/system/autodeploy_technochat.service
+	cp ./dist/autodeploy_technochat.timer /etc/systemd/system/
+	systemctl daemon-reload
+	systemctl enable --now autodeploy_technochat.timer
+
 vet:
 	go vet $(VET_PACKAGES)
 
@@ -69,4 +78,4 @@ clean:
 	rm -rf ui-tests/node_modules
 
 
-.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat vapid-keys lint install_autodeploy
+.PHONY: all clean test go-tests ui-unit-tests ui-e2e-tests ui-tests integration-tests install vet technochat vapid-keys lint install_autodeploy install_autodeploy_rc

--- a/README.md
+++ b/README.md
@@ -167,19 +167,20 @@ VAPID_PRIVATE_KEY=...
 VAPID_SUBJECT=admin@example.com
 ```
 
-By default, automatic deploy tracks the `master` branch and runs `./deploy.sh`.
-For RC, configure it once to track the force-updated `rc` branch and run the RC
-deploy mode:
-
-```bash
-AUTODEPLOY_BRANCH=rc
-AUTODEPLOY_ARGS=--rc
-```
+By default, automatic deploy tracks the `master` branch and runs production
+deploy. The autodeploy script also supports `--rc`; in that mode it tracks the
+force-updated `rc` branch and runs `./deploy.sh --rc`.
 
 Then run:
 
 ```bash
 make install_autodeploy
+```
+
+For RC automatic deploy, run:
+
+```bash
+make install_autodeploy_rc
 ```
 
 ## Let's Encrypt certificates

--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ VAPID_PRIVATE_KEY=...
 VAPID_SUBJECT=admin@example.com
 ```
 
+By default, automatic deploy tracks the `master` branch and runs `./deploy.sh`.
+For RC, configure it once to track the force-updated `rc` branch and run the RC
+deploy mode:
+
+```bash
+AUTODEPLOY_BRANCH=rc
+AUTODEPLOY_ARGS=--rc
+```
+
 Then run:
 
 ```bash

--- a/dist/autodeploy.sh
+++ b/dist/autodeploy.sh
@@ -1,23 +1,32 @@
 #!/bin/bash
 
-BRANCH="master"
-DEPLOY_SCRIPT="./deploy.sh"
+BRANCH="${AUTODEPLOY_BRANCH:-master}"
+DEPLOY_SCRIPT="${AUTODEPLOY_SCRIPT:-./deploy.sh}"
+DEPLOY_ARGS=()
+
+if [ -n "${AUTODEPLOY_ARGS:-}" ]; then
+    read -r -a DEPLOY_ARGS <<< "$AUTODEPLOY_ARGS"
+fi
 
 git -c safe.directory=$(pwd) remote set-url origin https://${GITHUB_TOKEN}@github.com/gibsn/technochat.git
 
-git -c safe.directory=$(pwd) checkout "$BRANCH"
-git -c safe.directory=$(pwd) fetch origin "$BRANCH"
+git -c safe.directory=$(pwd) fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
 
-LOCAL_HASH=$(git -c safe.directory=$(pwd) rev-parse "$BRANCH")
+if git -c safe.directory=$(pwd) show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    LOCAL_HASH=$(git -c safe.directory=$(pwd) rev-parse "$BRANCH")
+else
+    LOCAL_HASH=""
+fi
 REMOTE_HASH=$(git -c safe.directory=$(pwd) rev-parse "origin/$BRANCH")
 
 if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
+    git -c safe.directory=$(pwd) checkout -B "$BRANCH" "origin/$BRANCH"
     git -c safe.directory=$(pwd) reset --hard "origin/$BRANCH"
     chmod +x ./dist/autodeploy.sh
 
     COMMIT_MSG=$(git -c safe.directory=$(pwd) log -1 --pretty=%s "$REMOTE_HASH")
 
-    if bash "$DEPLOY_SCRIPT"; then
+    if bash "$DEPLOY_SCRIPT" "${DEPLOY_ARGS[@]}"; then
         STATUS="✅ Deploy successful"
     else
         STATUS="❌ Deploy failed"

--- a/dist/autodeploy.sh
+++ b/dist/autodeploy.sh
@@ -1,12 +1,31 @@
 #!/bin/bash
 
-BRANCH="${AUTODEPLOY_BRANCH:-master}"
-DEPLOY_SCRIPT="${AUTODEPLOY_SCRIPT:-./deploy.sh}"
+BRANCH="master"
+DEPLOY_SCRIPT="./deploy.sh"
 DEPLOY_ARGS=()
 
-if [ -n "${AUTODEPLOY_ARGS:-}" ]; then
-    read -r -a DEPLOY_ARGS <<< "$AUTODEPLOY_ARGS"
-fi
+print_help() {
+    echo "$0 checks a branch for updates and runs deploy when it changes"
+    echo -e "\tdefault:\ttrack master and run production deploy"
+    echo -e "\t--rc:\ttrack rc and run RC deploy"
+    echo -e "\t--help:\tprints this text and exits"
+}
+
+while [ "$1" != "" ]; do
+    case $1 in
+        "--rc")
+            BRANCH="rc"
+            DEPLOY_ARGS=(--rc)
+            ;;
+        "--help") print_help; exit 0;;
+        *)
+            echo "error: unknown option $1"
+            print_help
+            exit 1
+            ;;
+    esac
+    shift
+done
 
 git -c safe.directory=$(pwd) remote set-url origin https://${GITHUB_TOKEN}@github.com/gibsn/technochat.git
 

--- a/dist/autodeploy_technochat.service
+++ b/dist/autodeploy_technochat.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Auto-deploy technochat from master branch
+Description=Auto-deploy technochat
 Wants=network-online.target
 After=network-online.target
 

--- a/dist/autodeploy_technochat_rc.service
+++ b/dist/autodeploy_technochat_rc.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Auto-deploy technochat RC
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/technochat
+ExecStart=/opt/technochat/dist/autodeploy.sh --rc
+EnvironmentFile=/etc/default/autodeploy_technochat


### PR DESCRIPTION
## Summary
- add an explicit `--rc` mode to `dist/autodeploy.sh` that tracks the force-updated `rc` branch and runs `./deploy.sh --rc`
- keep the default autodeploy behavior on `master` for production
- add `make install_autodeploy_rc` and an RC systemd service variant so RC setup is a one-command install
- document the RC autodeploy path

## Checks
- `bash -n dist/autodeploy.sh`
- `bash dist/autodeploy.sh --help`
- `make lint`
- `make test`