### PR TITLE
Confirm chat leave action

### DIFF
--- a/docs/client-diagnostics.md
+++ b/docs/client-diagnostics.md
@@ -22,7 +22,7 @@ Most events include these fields automatically:
 - `data.standalone` - whether the app is running in standalone display mode.
 - `data.online` - current `navigator.onLine` value.
 - `data.visibility_state` - current `document.visibilityState`.
-- `data.participant_name` - participant name, included after the client knows it.
+- `data.participant_name` - participant name. Empty until the client knows it.
 
 Reconnect storage diagnostics may additionally include:
 

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -215,6 +215,18 @@ button {
   background: rgba(0, 0, 0, 0.28);
 }
 
+.leave_confirm_modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: max(18px, env(safe-area-inset-top)) 16px max(18px, env(safe-area-inset-bottom));
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.36);
+}
+
 .presence_panel {
   width: min(360px, 100%);
   max-height: min(430px, 72vh);
@@ -225,6 +237,15 @@ button {
   background: #ffffff;
   color: #111111;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.22);
+}
+
+.leave_confirm_panel {
+  width: min(440px, 100%);
+  overflow: hidden;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111111;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.24);
 }
 
 .presence_header {
@@ -239,9 +260,26 @@ button {
   flex-shrink: 0;
 }
 
+.leave_confirm_header {
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px 0 18px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  box-sizing: border-box;
+}
+
 .presence_header h2 {
   margin: 0;
   font-size: 22px;
+  line-height: 1.2;
+}
+
+.leave_confirm_header h2 {
+  margin: 0;
+  font-size: 20px;
   line-height: 1.2;
 }
 
@@ -266,6 +304,60 @@ button {
 .presence_close:focus {
   outline: 2px solid #111111;
   outline-offset: 2px;
+}
+
+.leave_confirm_body {
+  padding: 18px;
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+.leave_confirm_body p {
+  margin: 0 0 12px;
+}
+
+.leave_confirm_body ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.leave_confirm_body li + li {
+  margin-top: 8px;
+}
+
+.leave_confirm_actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 18px 18px;
+}
+
+.leave_confirm_cancel,
+.leave_confirm_leave {
+  min-height: 42px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.leave_confirm_cancel {
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  background: #ffffff;
+  color: #111111;
+}
+
+.leave_confirm_leave {
+  border: 0;
+  background: #b42318;
+  color: #ffffff;
+}
+
+.leave_confirm_cancel:focus-visible,
+.leave_confirm_leave:focus-visible {
+  outline: 2px solid #111111;
+  outline-offset: 3px;
 }
 
 .presence_list {

--- a/static/html/joinchat.html
+++ b/static/html/joinchat.html
@@ -181,7 +181,7 @@
                         <div class="leave_confirm_body">
                             <p>Leaving removes this chat from this device.</p>
                             <ul>
-                                <li>The local chat key and reconnect token will be deleted.</li>
+                                <li>You will not be able to reconnect to this chat from this device.</li>
                                 <li>Notifications for this chat will be disabled.</li>
                                 <li>Old push notifications may no longer be able to open this chat.</li>
                             </ul>

--- a/static/html/joinchat.html
+++ b/static/html/joinchat.html
@@ -74,7 +74,7 @@
                     <button
                         class="presence_icon_button leave_button"
                         type="button"
-                        @click="leaveChat"
+                        @click="requestLeaveChat"
                         aria-label="Leave chat"
                         title="Leave chat"
                     >
@@ -160,6 +160,39 @@
                                 >
                                 <span>{{ user.name }}</span>
                             </div>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    v-if="leaveConfirmOpen"
+                    class="leave_confirm_modal"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="leave_confirm_title"
+                    @click.self="cancelLeaveChat"
+                >
+                    <div class="leave_confirm_panel">
+                        <div class="leave_confirm_header">
+                            <h2 id="leave_confirm_title">Leave this chat?</h2>
+                            <button class="presence_close" type="button" @click="cancelLeaveChat" aria-label="Cancel">
+                                <i class="material-icons">close</i>
+                            </button>
+                        </div>
+                        <div class="leave_confirm_body">
+                            <p>Leaving removes this chat from this device.</p>
+                            <ul>
+                                <li>The local chat key and reconnect token will be deleted.</li>
+                                <li>Notifications for this chat will be disabled.</li>
+                                <li>Old push notifications may no longer be able to open this chat.</li>
+                            </ul>
+                        </div>
+                        <div class="leave_confirm_actions">
+                            <button class="leave_confirm_cancel" type="button" @click="cancelLeaveChat">
+                                Stay
+                            </button>
+                            <button class="leave_confirm_leave" type="button" @click="leaveChat">
+                                Leave chat
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/static/js/chat/chat.js
+++ b/static/js/chat/chat.js
@@ -80,10 +80,8 @@ function diagnosticContext(extra) {
         standalone: isStandalonePWA(),
         online: window.navigator.onLine,
         visibility_state: document.visibilityState,
+        participant_name: diagnosticParticipantName,
     };
-    if (diagnosticParticipantName) {
-        context.participant_name = diagnosticParticipantName;
-    }
 
     Object.keys(extra || {}).forEach(function(key) {
         context[key] = extra[key];
@@ -236,6 +234,7 @@ new Vue({
         reconnectSessionPersisted: false,
         reconnectSessionPersistAttempts: 0,
         iosHomePromptVisible: false,
+        leaveConfirmOpen: false,
     },
     computed: {
         presenceLabel: function() {
@@ -810,12 +809,19 @@ new Vue({
             this.reconnectToken = '';
             this.stopConnecting(status);
         },
+        requestLeaveChat: function() {
+            this.leaveConfirmOpen = true;
+        },
+        cancelLeaveChat: function() {
+            this.leaveConfirmOpen = false;
+        },
         leaveChat: function() {
             if (this.reconnectTimer) {
                 window.clearTimeout(this.reconnectTimer);
                 this.reconnectTimer = null;
             }
 
+            this.leaveConfirmOpen = false;
             reportChatDiagnostic('chat_leave_local', {
                 chat_id: this.chatID,
                 has_reconnect_token: Boolean(this.reconnectToken),

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -920,7 +920,7 @@ test("@unit local leave clears reconnect token without returning chat quota", as
 
   await expect(page.locator(".leave_confirm_modal")).toBeVisible();
   await expect(page.locator(".leave_confirm_body")).toContainText(
-    "The local chat key and reconnect token will be deleted."
+    "You will not be able to reconnect to this chat from this device."
   );
   await expect
     .poll(async () =>

--- a/ui-tests/tests/joinchat-title.spec.js
+++ b/ui-tests/tests/joinchat-title.spec.js
@@ -724,6 +724,22 @@ test("@unit sends push subscription only after reconnect session is stored", asy
   });
 });
 
+test("@unit includes participant name field in early client diagnostics", async ({
+  page,
+}) => {
+  const clientLogs = [];
+  await routeClientLogs(page, clientLogs);
+  await openJoinChat(page);
+
+  await waitForClientLog(page, () => {
+    return (window.__technochatClientLogs || []).some((log) => {
+      return log.event === "chat_join_page_start" &&
+        Object.prototype.hasOwnProperty.call(log.data, "participant_name") &&
+        log.data.participant_name === "";
+    });
+  });
+});
+
 test("@unit retries reconnect session storage before push subscribe", async ({
   page,
 }) => {
@@ -901,6 +917,27 @@ test("@unit local leave clears reconnect token without returning chat quota", as
 
   await expect(page.locator(".leave_button")).toBeVisible();
   await page.locator(".leave_button").click();
+
+  await expect(page.locator(".leave_confirm_modal")).toBeVisible();
+  await expect(page.locator(".leave_confirm_body")).toContainText(
+    "The local chat key and reconnect token will be deleted."
+  );
+  await expect
+    .poll(async () =>
+      page.evaluate(() => localStorage.getItem("technochat:chat:chat-id"))
+    )
+    .not.toBeNull();
+  await page.locator(".leave_confirm_cancel").click();
+  await expect(page.locator(".leave_confirm_modal")).toBeHidden();
+  await expect
+    .poll(async () =>
+      page.evaluate(() => localStorage.getItem("technochat:chat:chat-id"))
+    )
+    .not.toBeNull();
+
+  await page.locator(".leave_button").click();
+  await expect(page.locator(".leave_confirm_modal")).toBeVisible();
+  await page.locator(".leave_confirm_leave").click();
 
   await expect
     .poll(async () =>


### PR DESCRIPTION
## What changed
- Added a confirmation dialog before leaving a chat.
- The dialog spells out that leaving deletes the local chat key/reconnect token, disables notifications, and may make old push notifications unable to reopen the chat.
- Included `participant_name` in every client diagnostic event, using an empty string until the name is known.
- Updated diagnostics docs and UI tests for the new behavior.

## Why
A user reported `chat_leave_local` despite not intentionally leaving the chat. The confirmation step makes accidental Leave clicks much less likely and gives clearer evidence when a local leave is confirmed.

## Impact
Users now need to explicitly confirm before destructive local chat leave cleanup runs. Diagnostics become easier to correlate because `participant_name` is always present.
