### PR TITLE
Close older chat push notifications

### DIFF
--- a/internal/chat/push.go
+++ b/internal/chat/push.go
@@ -15,6 +15,7 @@ import (
 )
 
 const PushTTLSeconds = 24 * 60 * 60
+const pushProviderErrorBodyLimit = 4096
 
 var ErrPushSubscriptionGone = errors.New("push subscription expired or invalid")
 
@@ -118,22 +119,49 @@ func handlePushResponse(response *http.Response) error {
 	if response == nil {
 		return nil
 	}
-	if _, err := io.Copy(io.Discard, response.Body); err != nil {
-		_ = response.Body.Close()
-		return err
-	}
-	if err := response.Body.Close(); err != nil {
-		return err
+	var body []byte
+	if response.Body != nil {
+		limitedBody := io.LimitReader(response.Body, pushProviderErrorBodyLimit+1)
+		var err error
+		body, err = io.ReadAll(limitedBody)
+		if err != nil {
+			_ = response.Body.Close()
+			return err
+		}
+		if err := response.Body.Close(); err != nil {
+			return err
+		}
 	}
 
 	if response.StatusCode == http.StatusGone || response.StatusCode == http.StatusNotFound {
 		return ErrPushSubscriptionGone
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return fmt.Errorf("push provider returned %s", response.Status)
+		return fmt.Errorf(
+			"push provider returned %s: %s",
+			response.Status,
+			formatPushProviderErrorBody(body),
+		)
 	}
 
 	return nil
+}
+
+func formatPushProviderErrorBody(body []byte) string {
+	if len(body) == 0 {
+		return "empty response body"
+	}
+
+	truncated := len(body) > pushProviderErrorBodyLimit
+	if truncated {
+		body = body[:pushProviderErrorBodyLimit]
+	}
+
+	if truncated {
+		return fmt.Sprintf("%q (truncated)", string(body))
+	}
+
+	return fmt.Sprintf("%q", string(body))
 }
 
 func (c *Chat) UpsertPushSubscription(participantID int, subscription PushSubscription) bool {

--- a/internal/chat/push_test.go
+++ b/internal/chat/push_test.go
@@ -1,0 +1,59 @@
+package chat
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHandlePushResponseIncludesProviderErrorBody(t *testing.T) {
+	err := handlePushResponse(&http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     "400 Bad Request",
+		Body:       io.NopCloser(strings.NewReader(`{"error":"invalid vapid token"}`)),
+	})
+
+	if err == nil {
+		t.Fatal("expected push provider error")
+	}
+	if !strings.Contains(err.Error(), "push provider returned 400 Bad Request") {
+		t.Fatalf("expected status in error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), `{\"error\":\"invalid vapid token\"}`) {
+		t.Fatalf("expected escaped provider body in error, got %q", err.Error())
+	}
+}
+
+func TestHandlePushResponseLimitsProviderErrorBody(t *testing.T) {
+	err := handlePushResponse(&http.Response{
+		StatusCode: http.StatusBadRequest,
+		Status:     "400 Bad Request",
+		Body: io.NopCloser(strings.NewReader(
+			strings.Repeat("a", pushProviderErrorBodyLimit+1),
+		)),
+	})
+
+	if err == nil {
+		t.Fatal("expected push provider error")
+	}
+	if !strings.Contains(err.Error(), "(truncated)") {
+		t.Fatalf("expected truncated marker in error, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), strings.Repeat("a", pushProviderErrorBodyLimit+1)) {
+		t.Fatalf("expected provider body to be limited, got %q", err.Error())
+	}
+}
+
+func TestHandlePushResponseKeepsGoneSubscriptionSentinel(t *testing.T) {
+	err := handlePushResponse(&http.Response{
+		StatusCode: http.StatusGone,
+		Status:     "410 Gone",
+		Body:       io.NopCloser(strings.NewReader("expired")),
+	})
+
+	if !errors.Is(err, ErrPushSubscriptionGone) {
+		t.Fatalf("expected ErrPushSubscriptionGone, got %v", err)
+	}
+}

--- a/static/js/chat/push-subscription.js
+++ b/static/js/chat/push-subscription.js
@@ -36,12 +36,17 @@ export async function currentPushSubscription(requestPermission) {
         }
     }
 
+    const applicationServerKey = urlBase64ToUint8Array(publicKey);
     const registration = await navigator.serviceWorker.register('/sw.js');
     let subscription = await registration.pushManager.getSubscription();
+    if (subscription && !subscriptionMatchesApplicationServerKey(subscription, applicationServerKey)) {
+        await subscription.unsubscribe();
+        subscription = null;
+    }
     if (!subscription) {
         subscription = await registration.pushManager.subscribe({
             userVisibleOnly: true,
-            applicationServerKey: urlBase64ToUint8Array(publicKey),
+            applicationServerKey: applicationServerKey,
         });
     }
 
@@ -114,6 +119,33 @@ function normalizeSubscription(subscription) {
             p256dh: String(json && json.keys && json.keys.p256dh || ''),
         },
     };
+}
+
+export function subscriptionMatchesApplicationServerKey(subscription, applicationServerKey) {
+    const subscriptionKey = subscription && subscription.options ?
+        subscription.options.applicationServerKey :
+        null;
+    if (!subscriptionKey) {
+        return true;
+    }
+
+    return arrayBufferEquals(subscriptionKey, applicationServerKey);
+}
+
+function arrayBufferEquals(left, right) {
+    const leftBytes = new Uint8Array(left);
+    const rightBytes = new Uint8Array(right);
+    if (leftBytes.length !== rightBytes.length) {
+        return false;
+    }
+
+    for (let i = 0; i < leftBytes.length; i++) {
+        if (leftBytes[i] !== rightBytes[i]) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 function urlBase64ToUint8Array(base64String) {

--- a/static/sw.js
+++ b/static/sw.js
@@ -174,17 +174,20 @@ self.addEventListener('push', function (event) {
 self.addEventListener('notificationclick', function (event) {
   event.notification.close();
 
-  const chatId = event.notification && event.notification.data ?
-    event.notification.data.chatId :
-    '';
-  const messageId = event.notification && event.notification.data ?
-    event.notification.data.messageId :
-    '';
+  const notificationData = event.notification && event.notification.data ?
+    event.notification.data :
+    {};
+  const chatId = notificationData.chatId || '';
+  const messageId = notificationData.messageId || '';
   const url = chatId ?
     pushChatURL(chatId, messageId) :
     '/html/messageadd.html';
 
-  event.waitUntil(openClientURL(url));
+  event.waitUntil(
+    closeOlderChatNotifications(notificationData).then(function () {
+      return openClientURL(url);
+    })
+  );
 });
 
 self.addEventListener('pushsubscriptionchange', function (event) {
@@ -206,7 +209,9 @@ function handlePush(event) {
       renotify: true,
       data: {
         chatId: payload.chatId,
-        messageId: payload.messageId
+        messageId: payload.messageId,
+        messageSeq: payload.messageSeq,
+        timestamp: payload.timestamp
       }
     });
   });
@@ -337,6 +342,62 @@ function openClientURL(url) {
 
     return self.clients.openWindow(url);
   });
+}
+
+function closeOlderChatNotifications(openedData) {
+  if (!self.registration || !self.registration.getNotifications) {
+    return Promise.resolve();
+  }
+
+  return self.registration.getNotifications().then(function (notifications) {
+    notifications.forEach(function (notification) {
+      if (shouldCloseOlderChatNotification(openedData, notification.data || {})) {
+        notification.close();
+      }
+    });
+  });
+}
+
+function shouldCloseOlderChatNotification(openedData, candidateData) {
+  if (!openedData || !candidateData || !openedData.chatId) {
+    return false;
+  }
+  if (candidateData.chatId !== openedData.chatId) {
+    return false;
+  }
+  if (candidateData.messageId && candidateData.messageId === openedData.messageId) {
+    return false;
+  }
+
+  const openedSeq = normalizedMessageSeq(openedData.messageSeq);
+  const candidateSeq = normalizedMessageSeq(candidateData.messageSeq);
+  if (openedSeq && candidateSeq) {
+    return candidateSeq < openedSeq;
+  }
+  if (openedSeq && !candidateSeq) {
+    return true;
+  }
+  if (!openedSeq && candidateSeq) {
+    return false;
+  }
+
+  const openedTimestamp = normalizedTimestamp(openedData.timestamp);
+  const candidateTimestamp = normalizedTimestamp(candidateData.timestamp);
+  if (openedTimestamp && candidateTimestamp) {
+    return candidateTimestamp < openedTimestamp;
+  }
+
+  return Boolean(openedData.messageId && candidateData.messageId);
+}
+
+function normalizedMessageSeq(value) {
+  const seq = Number(value);
+  return Number.isFinite(seq) && seq > 0 ? seq : 0;
+}
+
+function normalizedTimestamp(value) {
+  const timestamp = Date.parse(value || '');
+  return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
 function savePushMessage(payload) {

--- a/static/sw.js
+++ b/static/sw.js
@@ -184,7 +184,7 @@ self.addEventListener('notificationclick', function (event) {
     '/html/messageadd.html';
 
   event.waitUntil(
-    closeOlderChatNotifications(notificationData).then(function () {
+    closeChatNotifications(notificationData).then(function () {
       return openClientURL(url);
     })
   );
@@ -344,60 +344,25 @@ function openClientURL(url) {
   });
 }
 
-function closeOlderChatNotifications(openedData) {
+function closeChatNotifications(openedData) {
   if (!self.registration || !self.registration.getNotifications) {
     return Promise.resolve();
   }
 
   return self.registration.getNotifications().then(function (notifications) {
     notifications.forEach(function (notification) {
-      if (shouldCloseOlderChatNotification(openedData, notification.data || {})) {
+      if (shouldCloseChatNotification(openedData, notification.data || {})) {
         notification.close();
       }
     });
   });
 }
 
-function shouldCloseOlderChatNotification(openedData, candidateData) {
+function shouldCloseChatNotification(openedData, candidateData) {
   if (!openedData || !candidateData || !openedData.chatId) {
     return false;
   }
-  if (candidateData.chatId !== openedData.chatId) {
-    return false;
-  }
-  if (candidateData.messageId && candidateData.messageId === openedData.messageId) {
-    return false;
-  }
-
-  const openedSeq = normalizedMessageSeq(openedData.messageSeq);
-  const candidateSeq = normalizedMessageSeq(candidateData.messageSeq);
-  if (openedSeq && candidateSeq) {
-    return candidateSeq < openedSeq;
-  }
-  if (openedSeq && !candidateSeq) {
-    return true;
-  }
-  if (!openedSeq && candidateSeq) {
-    return false;
-  }
-
-  const openedTimestamp = normalizedTimestamp(openedData.timestamp);
-  const candidateTimestamp = normalizedTimestamp(candidateData.timestamp);
-  if (openedTimestamp && candidateTimestamp) {
-    return candidateTimestamp < openedTimestamp;
-  }
-
-  return Boolean(openedData.messageId && candidateData.messageId);
-}
-
-function normalizedMessageSeq(value) {
-  const seq = Number(value);
-  return Number.isFinite(seq) && seq > 0 ? seq : 0;
-}
-
-function normalizedTimestamp(value) {
-  const timestamp = Date.parse(value || '');
-  return Number.isFinite(timestamp) ? timestamp : 0;
+  return candidateData.chatId === openedData.chatId;
 }
 
 function savePushMessage(payload) {

--- a/ui-tests/tests/push-subscription.unit.spec.js
+++ b/ui-tests/tests/push-subscription.unit.spec.js
@@ -1,0 +1,45 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/push-subscription-test.html", async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: "<!doctype html><title>push subscription test</title>",
+    });
+  });
+
+  await page.route("**/js/chat/push-subscription.js", async (route) => {
+    await route.fulfill({
+      contentType: "application/javascript",
+      path: path.join(__dirname, "../../static/js/chat/push-subscription.js"),
+    });
+  });
+});
+
+test("@unit detects push subscription VAPID key mismatches", async ({ page }) => {
+  await page.goto("/push-subscription-test.html");
+
+  const decisions = await page.evaluate(async () => {
+    const module = await import("/js/chat/push-subscription.js");
+    const currentKey = new Uint8Array([1, 2, 3]).buffer;
+
+    return {
+      sameKey: module.subscriptionMatchesApplicationServerKey({
+        options: { applicationServerKey: new Uint8Array([1, 2, 3]).buffer },
+      }, currentKey),
+      differentKey: module.subscriptionMatchesApplicationServerKey({
+        options: { applicationServerKey: new Uint8Array([1, 2, 4]).buffer },
+      }, currentKey),
+      missingKey: module.subscriptionMatchesApplicationServerKey({
+        options: {},
+      }, currentKey),
+    };
+  });
+
+  await expect(decisions).toEqual({
+    sameKey: true,
+    differentKey: false,
+    missingKey: true,
+  });
+});

--- a/ui-tests/tests/service-worker-notifications.unit.spec.js
+++ b/ui-tests/tests/service-worker-notifications.unit.spec.js
@@ -1,0 +1,96 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/service-worker-notifications-test.html", async (route) => {
+    await route.fulfill({
+      contentType: "text/html",
+      body: "<!doctype html><title>service worker notifications test</title><script src=\"/sw.js\"></script>",
+    });
+  });
+
+  await page.route("**/sw.js", async (route) => {
+    await route.fulfill({
+      contentType: "application/javascript",
+      path: path.join(__dirname, "../../static/sw.js"),
+    });
+  });
+});
+
+test("@unit closes only older notifications for the opened chat", async ({ page }) => {
+  await page.goto("/service-worker-notifications-test.html");
+
+  const decisions = await page.evaluate(() => {
+    const opened = {
+      chatId: "chat-id",
+      messageId: "opened",
+      messageSeq: 3,
+      timestamp: "2026-05-14T03:00:00Z",
+    };
+
+    return {
+      olderSameChat: shouldCloseOlderChatNotification(opened, {
+        chatId: "chat-id",
+        messageId: "older",
+        messageSeq: 2,
+      }),
+      openedMessage: shouldCloseOlderChatNotification(opened, {
+        chatId: "chat-id",
+        messageId: "opened",
+        messageSeq: 3,
+      }),
+      newerSameChat: shouldCloseOlderChatNotification(opened, {
+        chatId: "chat-id",
+        messageId: "newer",
+        messageSeq: 4,
+      }),
+      otherChat: shouldCloseOlderChatNotification(opened, {
+        chatId: "other-chat",
+        messageId: "older",
+        messageSeq: 1,
+      }),
+      legacySameChat: shouldCloseOlderChatNotification(opened, {
+        chatId: "chat-id",
+        messageId: "legacy",
+      }),
+    };
+  });
+
+  await expect(decisions).toEqual({
+    olderSameChat: true,
+    openedMessage: false,
+    newerSameChat: false,
+    otherChat: false,
+    legacySameChat: true,
+  });
+});
+
+test("@unit falls back to timestamps when notification sequence is absent", async ({ page }) => {
+  await page.goto("/service-worker-notifications-test.html");
+
+  const decisions = await page.evaluate(() => {
+    const opened = {
+      chatId: "chat-id",
+      messageId: "opened",
+      timestamp: "2026-05-14T03:00:00Z",
+    };
+
+    return {
+      olderSameChat: shouldCloseOlderChatNotification(opened, {
+        chatId: "chat-id",
+        messageId: "older",
+        timestamp: "2026-05-14T02:00:00Z",
+      }),
+      newerSameChat: shouldCloseOlderChatNotification(opened, {
+        chatId: "chat-id",
+        messageId: "newer",
+        timestamp: "2026-05-14T04:00:00Z",
+      }),
+    };
+  });
+
+  await expect(decisions).toEqual({
+    olderSameChat: true,
+    newerSameChat: false,
+  });
+});

--- a/ui-tests/tests/service-worker-notifications.unit.spec.js
+++ b/ui-tests/tests/service-worker-notifications.unit.spec.js
@@ -17,7 +17,7 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test("@unit closes only older notifications for the opened chat", async ({ page }) => {
+test("@unit closes all notifications for the opened chat", async ({ page }) => {
   await page.goto("/service-worker-notifications-test.html");
 
   const decisions = await page.evaluate(() => {
@@ -29,27 +29,27 @@ test("@unit closes only older notifications for the opened chat", async ({ page 
     };
 
     return {
-      olderSameChat: shouldCloseOlderChatNotification(opened, {
+      olderSameChat: shouldCloseChatNotification(opened, {
         chatId: "chat-id",
         messageId: "older",
         messageSeq: 2,
       }),
-      openedMessage: shouldCloseOlderChatNotification(opened, {
+      openedMessage: shouldCloseChatNotification(opened, {
         chatId: "chat-id",
         messageId: "opened",
         messageSeq: 3,
       }),
-      newerSameChat: shouldCloseOlderChatNotification(opened, {
+      newerSameChat: shouldCloseChatNotification(opened, {
         chatId: "chat-id",
         messageId: "newer",
         messageSeq: 4,
       }),
-      otherChat: shouldCloseOlderChatNotification(opened, {
+      otherChat: shouldCloseChatNotification(opened, {
         chatId: "other-chat",
         messageId: "older",
         messageSeq: 1,
       }),
-      legacySameChat: shouldCloseOlderChatNotification(opened, {
+      legacySameChat: shouldCloseChatNotification(opened, {
         chatId: "chat-id",
         messageId: "legacy",
       }),
@@ -58,14 +58,14 @@ test("@unit closes only older notifications for the opened chat", async ({ page 
 
   await expect(decisions).toEqual({
     olderSameChat: true,
-    openedMessage: false,
-    newerSameChat: false,
+    openedMessage: true,
+    newerSameChat: true,
     otherChat: false,
     legacySameChat: true,
   });
 });
 
-test("@unit falls back to timestamps when notification sequence is absent", async ({ page }) => {
+test("@unit ignores notification ordering when closing opened chat notifications", async ({ page }) => {
   await page.goto("/service-worker-notifications-test.html");
 
   const decisions = await page.evaluate(() => {
@@ -76,12 +76,12 @@ test("@unit falls back to timestamps when notification sequence is absent", asyn
     };
 
     return {
-      olderSameChat: shouldCloseOlderChatNotification(opened, {
+      olderSameChat: shouldCloseChatNotification(opened, {
         chatId: "chat-id",
         messageId: "older",
         timestamp: "2026-05-14T02:00:00Z",
       }),
-      newerSameChat: shouldCloseOlderChatNotification(opened, {
+      newerSameChat: shouldCloseChatNotification(opened, {
         chatId: "chat-id",
         messageId: "newer",
         timestamp: "2026-05-14T04:00:00Z",
@@ -91,6 +91,6 @@ test("@unit falls back to timestamps when notification sequence is absent", asyn
 
   await expect(decisions).toEqual({
     olderSameChat: true,
-    newerSameChat: false,
+    newerSameChat: true,
   });
 });


### PR DESCRIPTION
## Summary
- close older push notifications for the same chat when a user opens one notification
- keep newer notifications and notifications from other chats intact
- cover sequence-based and timestamp fallback notification cleanup in UI unit tests

## Details
When several chat push notifications arrive, each notification has its own tag, so opening one did not clear earlier notifications for that chat. The service worker now stores `messageSeq` and `timestamp` in notification data and closes older notifications for the same chat before opening the chat window.

closes #131
